### PR TITLE
mFactor implementation in radiator

### DIFF
--- a/IDEAS/Fluid/HeatExchangers/Radiators/Radiator.mo
+++ b/IDEAS/Fluid/HeatExchangers/Radiators/Radiator.mo
@@ -2,8 +2,10 @@ within IDEAS.Fluid.HeatExchangers.Radiators;
 model Radiator "Simple 1-node radiator model according to EN 442"
   extends IDEAS.Fluid.HeatExchangers.Interfaces.EmissionTwoPort;
    extends IDEAS.Fluid.Interfaces.Partials.PipeTwoPort(
-     final m=mMedium+mDry*cpDry/Medium.specificHeatCapacityCp(state_default),
-     final m_flow_nominal=QNom/Medium.specificHeatCapacityCp(state_default)/(TInNom -TOutNom));
+     final m=mMedium,
+     final m_flow_nominal=QNom/Medium.specificHeatCapacityCp(state_default)/(TInNom -TOutNom),
+    vol(final mFactor=mDry*cpDry/Medium.specificHeatCapacityCp(state_default)/mMedium +
+          1));
 
   parameter Modelica.SIunits.Temperature TInNom=75 + 273.15
     "Nominal inlet temperature";


### PR DESCRIPTION
Implemented thermal mass in radiator using mFactor instead of adding extra volume. This should not influence results since species concentrations are typically not of importance in radiator models, but it's the more correct way to model the extra thermal mass.
