### PR TITLE
set default medium to IDEAS.Media.Water in the most important models

### DIFF
--- a/IDEAS/Fluid/Interfaces/PartialTwoPort.mo
+++ b/IDEAS/Fluid/Interfaces/PartialTwoPort.mo
@@ -2,8 +2,8 @@ within IDEAS.Fluid.Interfaces;
 partial model PartialTwoPort "Partial component with two ports"
   import Modelica.Constants;
 
-  replaceable package Medium =
-      Modelica.Media.Interfaces.PartialMedium "Medium in the component"
+  replaceable package Medium =Modelica.Media.Interfaces.PartialMedium
+    "Medium in the component"
       annotation (choicesAllMatching = true);
 
   parameter Boolean allowFlowReversal = true

--- a/IDEAS/Fluid/Interfaces/Partials/PartialTwoPort.mo
+++ b/IDEAS/Fluid/Interfaces/Partials/PartialTwoPort.mo
@@ -1,7 +1,9 @@
 within IDEAS.Fluid.Interfaces.Partials;
 partial model PartialTwoPort
   "Partial model of two port without internal connections"
-  extends IDEAS.Fluid.Interfaces.LumpedVolumeDeclarations;
+  extends IDEAS.Fluid.Interfaces.LumpedVolumeDeclarations(redeclare
+      replaceable package Medium =
+        IDEAS.Media.Water);
   extends IDEAS.Fluid.Interfaces.PartialTwoPortInterface;
 
   parameter Modelica.SIunits.Mass m(start=1) = 1 "Mass of medium";
@@ -34,7 +36,10 @@ partial model PartialTwoPort
     p_start=p_start,
     allowFlowReversal=allowFlowReversal,
     nPorts=1,
-    final V=m/Medium.density(Medium.setState_phX(Medium.p_default, Medium.h_default, Medium.X_default)))
+    final V=m/Medium.density(Medium.setState_phX(Medium.p_default, Medium.h_default, Medium.X_default)),
+    C_nominal=C_nominal,
+    mFactor=mFactor,
+    m_flow_small=m_flow_small)
     annotation (Placement(transformation(extent={{-44,0},{-64,20}})));
 
   parameter Boolean dynamicBalance = true

--- a/IDEAS/Fluid/Interfaces/Partials/PipeTwoPort.mo
+++ b/IDEAS/Fluid/Interfaces/Partials/PipeTwoPort.mo
@@ -2,7 +2,7 @@ within IDEAS.Fluid.Interfaces.Partials;
 model PipeTwoPort "Two port containing a volume and pressure drop"
   extends IDEAS.Fluid.Interfaces.Partials.PartialTwoPort(vol(nPorts=2));
   extends IDEAS.Fluid.Interfaces.TwoPortFlowResistanceParameters(
-    final computeFlowResistance=true, dp_nominal = 0);
+    dp_nominal = 0);
 
   IDEAS.Fluid.FixedResistances.FixedResistanceDpM res(
     redeclare package Medium = Medium,
@@ -14,7 +14,7 @@ model PipeTwoPort "Two port containing a volume and pressure drop"
     final from_dp=from_dp,
     final linearized=linearizeFlowResistance,
     final homotopyInitialization=homotopyInitialization,
-    final dp_nominal=dp_nominal)
+    final dp_nominal=if computeFlowResistance then dp_nominal else 0)
     annotation (Placement(transformation(extent={{4,-10},{24,10}})));
   //Advanced settings: based on IDEAS.Fluid.Interfaces.TwoPortHeatMassExchanger
   parameter Boolean homotopyInitialization = true "= true, use homotopy method"
@@ -25,7 +25,7 @@ equation
       color={0,127,255},
       smooth=Smooth.None));
   connect(res.port_b, port_b) annotation (Line(
-      points={{24,0},{62,0},{62,0},{100,0}},
+      points={{24,0},{100,0}},
       color={0,127,255},
       smooth=Smooth.None));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,

--- a/IDEAS/Fluid/Production/Interfaces/PartialDynamicHeaterWithLosses.mo
+++ b/IDEAS/Fluid/Production/Interfaces/PartialDynamicHeaterWithLosses.mo
@@ -6,7 +6,9 @@ model PartialDynamicHeaterWithLosses
   import IDEAS.Fluid.Production.BaseClasses.HeaterType;
   extends IDEAS.Fluid.Interfaces.TwoPortFlowResistanceParameters(
     final computeFlowResistance=true, dp_nominal = 0);
-  extends IDEAS.Fluid.Interfaces.LumpedVolumeDeclarations(T_start=293.15);
+  extends IDEAS.Fluid.Interfaces.LumpedVolumeDeclarations(T_start=293.15, redeclare
+      replaceable package Medium =
+        IDEAS.Media.Water);
 
   parameter HeaterType heaterType
     "Type of the heater, is used mainly for post processing";

--- a/IDEAS/Fluid/Storage/StorageTank.mo
+++ b/IDEAS/Fluid/Storage/StorageTank.mo
@@ -1,7 +1,8 @@
 within IDEAS.Fluid.Storage;
 model StorageTank "1D multinode stratified storage tank"
 
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+  replaceable package Medium = IDEAS.Media.Water constrainedby
+    Modelica.Media.Interfaces.PartialMedium
     annotation (__Dymola_choicesAllMatching=true);
   //Tank geometry and composition
   parameter Integer nbrNodes(min=1) = 10 "Number of nodes";

--- a/IDEAS/Fluid/Storage/StorageTank_OneIntHX.mo
+++ b/IDEAS/Fluid/Storage/StorageTank_OneIntHX.mo
@@ -1,9 +1,11 @@
 within IDEAS.Fluid.Storage;
 model StorageTank_OneIntHX
   "1D multinode stratified storage tank with one internal heat exchanger (HX)"
-  replaceable package MediumHX = Modelica.Media.Interfaces.PartialMedium
+  replaceable package MediumHX = IDEAS.Media.Water constrainedby
+    Modelica.Media.Interfaces.PartialMedium
     annotation (__Dymola_choicesAllMatching=true);
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+  replaceable package Medium = IDEAS.Media.Water constrainedby
+    Modelica.Media.Interfaces.PartialMedium
     annotation (__Dymola_choicesAllMatching=true);
   //Tank geometry and composition
   constant Medium.ThermodynamicState state_default=


### PR DESCRIPTION
This pull request also propagates two parameters to the top level in PartialTwoPort and adds the possibility to disable the flow resistance calculation in PipeTwoPort.

Default media in HeatPump will follow
