### PR TITLE
Protected components in BaseCircuits

### DIFF
--- a/IDEAS/Buildings/Components/Zone.mo
+++ b/IDEAS/Buildings/Components/Zone.mo
@@ -49,7 +49,6 @@ protected
     nin=2,
     k={0.5,0.5})
     annotation (Placement(transformation(extent={{0,-66},{12,-54}})));
-public
   Fluid.MixingVolumes.MixingVolume         vol(
     V=V,
     m_flow_nominal=m_flow_nominal,
@@ -68,10 +67,12 @@ public
         extent={{-10,-10},{10,10}},
         rotation=180,
         origin={-10,30})));
+public
   Fluid.Interfaces.FlowPort_b flowPort_Out(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-30,90},{-10,110}})));
   Fluid.Interfaces.FlowPort_a flowPort_In(redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{10,90},{30,110}})));
+protected
   Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor senTem
     annotation (Placement(transformation(extent={{0,-28},{-16,-12}})));
   parameter Boolean allowFlowReversal=system.allowFlowReversal

--- a/IDEAS/Controls/Discrete/Examples/package.mo
+++ b/IDEAS/Controls/Discrete/Examples/package.mo
@@ -2,6 +2,7 @@ within IDEAS.Controls.Discrete;
 package Examples "Collection of models that illustrate model use and test models"
   extends Modelica.Icons.ExamplesPackage;
 
+
 annotation (preferredView="info", Documentation(info="<html>
 <p>
 This package contains examples for the use of models that can be found in

--- a/IDEAS/Controls/Discrete/HysteresisRelease_boolean.mo
+++ b/IDEAS/Controls/Discrete/HysteresisRelease_boolean.mo
@@ -1,0 +1,162 @@
+within IDEAS.Controls.Discrete;
+block HysteresisRelease_boolean
+  "Hysteresis for cooling mode WITH events, with Real in- and output, and inputs for uLow and uHigh"
+  extends Modelica.Blocks.Interfaces.SISO(y(start=if y_start then 1 else 0, min=0, max=1));
+  parameter Boolean revert = false
+    "Set to true if the hysteresis returns true when u < uLow instead of u > uHigh (for example for heating put revert = true)";
+  parameter Boolean use_input = true
+    "If true, use realinput signals for uLow and uHigh instead of fixed parameters";
+  parameter Boolean enableRelease=false
+    "if true, an additional RealInput will be available for releasing the controller";
+  Modelica.Blocks.Interfaces.RealInput uLow if use_input
+    annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
+  Modelica.Blocks.Interfaces.RealInput uHigh if use_input
+    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
+  parameter Real uLow_val = 0
+    "lower boundary value if the input uLow is not used"
+    annotation(Dialog(enable=not use_input));
+  parameter Real uHigh_val = 1
+    "higher boundary value if the input uHigh is not used"
+    annotation(Dialog(enable=not use_input));
+  Modelica.Blocks.Interfaces.BooleanInput release(start=false) = rel_internal if enableRelease
+    "if < 0.5, the controller is OFF"
+    annotation (Placement(transformation(extent={{-20,-20},{20,20}},
+        rotation=90,
+        origin={0,-120})));
+  parameter Boolean y_start = false "Output of controller at initial time";
+protected
+  Modelica.Blocks.Interfaces.RealInput uLow_internal
+    "Needed to connect to conditional connector";
+  Modelica.Blocks.Interfaces.RealInput uHigh_internal
+    "Needed to connect to conditional connector";
+  Boolean rel_internal
+    "release, either 1 ,either from RealInput release if enableRelease is true";
+  Boolean y_boolean "Boolean control signal, will be converted to Real";
+initial equation
+  pre(y_boolean) = y_start;
+equation
+  if not enableRelease then
+    rel_internal = true;
+  end if;
+  connect(uLow,uLow_internal);
+  connect(uHigh,uHigh_internal);
+  // Needed to connect to conditional connector
+  if not use_input then
+    uLow_internal = uLow_val;
+    uHigh_internal = uHigh_val;
+  end if;
+  if rel_internal then
+    if not revert then
+      y_boolean = u > uHigh_internal or pre(y_boolean) and u >= uLow_internal;
+    else
+      y_boolean = u < uLow_internal or pre(y_boolean) and u <= uHigh_internal;
+    end if;
+  else
+    y_boolean = false;
+  end if;
+  y = if y_boolean then 1 else 0;
+  annotation (
+    Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},{100,
+            100}}), graphics={Polygon(
+          points={{-65,89},{-73,67},{-57,67},{-65,89}},
+          lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid),Line(points={{-65,67},{-65,-81}},
+          color={192,192,192}),Line(points={{-90,-70},{82,-70}}, color={192,192,
+          192}),Polygon(
+          points={{90,-70},{68,-62},{68,-78},{90,-70}},
+          lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid),Text(
+          extent={{70,-80},{94,-100}},
+          lineColor={160,160,164},
+          textString="u"),Text(
+          extent={{-65,93},{-12,75}},
+          lineColor={160,160,164},
+          textString="y"),Line(
+          points={{-80,-70},{30,-70}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{-50,10},{80,10}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{-50,10},{-50,-70}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{30,10},{30,-70}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{-10,-65},{0,-70},{-10,-75}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{-10,15},{-20,10},{-10,5}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{-55,-20},{-50,-30},{-44,-20}},
+          color={0,0,0},
+          thickness=0.5),Line(
+          points={{25,-30},{30,-19},{35,-30}},
+          color={0,0,0},
+          thickness=0.5),Text(
+          extent={{-99,2},{-70,18}},
+          lineColor={160,160,164},
+          textString="true"),Text(
+          extent={{-98,-87},{-66,-73}},
+          lineColor={160,160,164},
+          textString="false"),Text(
+          extent={{19,-87},{44,-70}},
+          lineColor={0,0,0},
+          textString="uHigh"),Text(
+          extent={{-63,-88},{-38,-71}},
+          lineColor={0,0,0},
+          textString="uLow"),Line(points={{-69,10},{-60,10}}, color={160,160,
+          164})}),
+    Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
+            100}}), graphics={Polygon(
+          points={{-80,90},{-88,68},{-72,68},{-80,90}},
+          lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid),Line(points={{-80,68},{-80,-29}},
+          color={192,192,192}),Polygon(
+          points={{92,-29},{70,-21},{70,-37},{92,-29}},
+          lineColor={192,192,192},
+          fillColor={192,192,192},
+          fillPattern=FillPattern.Solid),Line(points={{-79,-29},{84,-29}},
+          color={192,192,192}),Line(points={{-79,-29},{41,-29}}, color={0,0,0}),
+          Line(points={{-15,-21},{1,-29},{-15,-36}}, color={0,0,0}),Line(points=
+           {{41,51},{41,-29}}, color={0,0,0}),Line(points={{33,3},{41,22},{50,3}},
+          color={0,0,0}),Line(points={{-49,51},{81,51}}, color={0,0,0}),Line(
+          points={{-4,59},{-19,51},{-4,43}}, color={0,0,0}),Line(points={{-59,
+          29},{-49,11},{-39,29}}, color={0,0,0}),Line(points={{-49,51},{-49,-29}},
+          color={0,0,0}),Text(
+          extent={{-92,-49},{-9,-92}},
+          lineColor={192,192,192},
+          textString="%uLow"),Text(
+          extent={{2,-49},{91,-92}},
+          lineColor={192,192,192},
+          textString="%uHigh"),Rectangle(extent={{-91,-49},{-8,-92}}, lineColor=
+           {192,192,192}),Line(points={{-49,-29},{-49,-49}}, color={192,192,192}),
+          Rectangle(extent={{2,-49},{91,-92}}, lineColor={192,192,192}),Line(
+          points={{41,-29},{41,-49}}, color={192,192,192})}),
+    Documentation(info="<html>
+<p>This block transforms a <b>Real</b> input signal into a <b>Real</b> output signal: </p>
+<ul>
+<li>When the output was false and the input becomes greater than parameter uHigh, the output switches to true.</li>
+<li>When the output was true and the input becomes less than parameter uLow, the output switches to false.</li>
+<li>As long as the input stays between uLow and uHigh, the output remains the same.</li>
+</ul>
+<p><br>This hysteresic block has several additional features:</p>
+<ul>
+<li>When the parameter revert is true, the switching logic changes.  This is typically used for heating-like situations, when the output has to be true when the input is below uLow. </li>
+<li>uLow and uHigh can be realinputs instead of fixed parameters</li>
+<li>a release input can be used to activate (release) or deactivate  the controller</li>
+</ul>
+<p>The initial value of the output is defined via parameter y_start. The default value of this parameter is false. </p>
+</html>",
+  revisions="<html>
+<ul>
+<li>November 2014, Roel De Coninck<br>Switching to real inputs and output</li>
+<li>May 13, 2014, by Damien Picard:<br>Add possibility to use parameters as boundary values instead of inputs. </li>
+</ul>
+</html>"));
+end HysteresisRelease_boolean;

--- a/IDEAS/Controls/Discrete/package.mo
+++ b/IDEAS/Controls/Discrete/package.mo
@@ -2,6 +2,7 @@ within IDEAS.Controls;
 package Discrete "Package with models for discrete time controls"
   extends Modelica.Icons.Package;
 
+
 annotation (
 preferredView="info", Documentation(info="<html>
 This package contains components models for discrete time controls.

--- a/IDEAS/Controls/Discrete/package.order
+++ b/IDEAS/Controls/Discrete/package.order
@@ -1,3 +1,4 @@
 BooleanDelay
 HysteresisRelease
 Examples
+HysteresisRelease_boolean

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/CircuitInterface.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/CircuitInterface.mo
@@ -53,7 +53,30 @@ partial model CircuitInterface "Partial circuit for base circuits"
   parameter Modelica.SIunits.MassFlowRate m_flow_small(min=0) = 1E-4*abs(m_flow_nominal)
     "Small mass flow rate for regularization of zero flow";
 
-  //Components
+  // Components ----------------------------------------------------------------
+
+public
+  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if includePipes
+    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
+  Modelica.Blocks.Interfaces.RealOutput Tsup if measureSupplyT
+    "Supply temperature" annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={70,108}), iconTransformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={76,104})));
+
+  Modelica.Blocks.Interfaces.RealOutput Tret if measureReturnT
+    "Return temperature" annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-70,-108}), iconTransformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-76,-104})));
+
+protected
   FixedResistances.InsulatedPipe pipeSupply(
     UA=UA,
     m=m/2,
@@ -64,8 +87,6 @@ partial model CircuitInterface "Partial circuit for base circuits"
         extent={{10,-10},{-10,10}},
         rotation=180,
         origin={-80,60})), choicesAllMatching=true);
-  Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPort if includePipes
-    annotation (Placement(transformation(extent={{-10,-110},{10,-90}})));
   FixedResistances.InsulatedPipe pipeReturn(
     UA=UA,
     dp_nominal=dp,
@@ -79,28 +100,10 @@ partial model CircuitInterface "Partial circuit for base circuits"
       redeclare package Medium = Medium) if
                                        measureSupplyT
     annotation (Placement(transformation(extent={{60,50},{80,70}})));
-  Modelica.Blocks.Interfaces.RealOutput Tsup if
-                                             measureSupplyT
-    "Supply temperature" annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=90,
-        origin={70,108}), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=90,
-        origin={76,104})));
   Sensors.TemperatureTwoPort senTemRet(m_flow_nominal=m_flow_nominal,
       redeclare package Medium = Medium) if
                                        measureReturnT
     annotation (Placement(transformation(extent={{-60,-50},{-80,-70}})));
-  Modelica.Blocks.Interfaces.RealOutput Tret if
-                                             measureReturnT
-    "Return temperature" annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-70,-108}), iconTransformation(
-        extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-76,-104})));
 equation
 
   connect(port_a1, pipeSupply.port_a) annotation (Line(

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialBaseCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialBaseCircuit.mo
@@ -2,7 +2,8 @@ within IDEAS.Fluid.BaseCircuits.Interfaces;
 partial model PartialBaseCircuit "Partial for a mixing circuit"
   import IDEAS;
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends CircuitInterface;
 
 equation

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialCircuitBalancingValve.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialCircuitBalancingValve.mo
@@ -1,16 +1,20 @@
 within IDEAS.Fluid.BaseCircuits.Interfaces;
 partial model PartialCircuitBalancingValve
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends ValveParametersReturn;
   extends PartialBaseCircuit( pipeReturn(dp_nominal=0));
 
-  //Parameter
+  // Parameter -----------------------------------------------------------------
+
   parameter Boolean useBalancingValve=false
     "Set to true to include a balancing valve"
     annotation(Dialog(group = "Settings"));
 
-  //Components
+  // Components ----------------------------------------------------------------
+
+protected
   FixedResistances.FixedResistanceDpM       balancingValve(
         final deltaM=deltaMReturn,
     redeclare package Medium = Medium,

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialFlowCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialFlowCircuit.mo
@@ -2,18 +2,24 @@ within IDEAS.Fluid.BaseCircuits.Interfaces;
 model PartialFlowCircuit
   import IDEAS;
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends PartialCircuitBalancingValve;
 
-  //Parameters
+  // Parameters ----------------------------------------------------------------
+
   parameter Boolean measurePower=true
     "Set to false to remove the power consumption measurement of the flow regulator"
     annotation(Dialog(group = "Settings"));
+  // Components ----------------------------------------------------------------
 
+protected
   replaceable IDEAS.Fluid.Interfaces.PartialTwoPortInterface flowRegulator(
     redeclare package Medium = Medium,
     m_flow_nominal=m_flow_nominal)
     annotation (Placement(transformation(extent={{-10,50},{10,70}})));
+
+public
   Modelica.Blocks.Interfaces.RealInput u "Setpoint of the flow regulator"
     annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialMixingCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialMixingCircuit.mo
@@ -1,18 +1,22 @@
 within IDEAS.Fluid.BaseCircuits.Interfaces;
 model PartialMixingCircuit "Partial for a circuit containing a three way valve"
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends ValveParametersSupply(
     rhoStdSupply=Medium.density_pTX(101325, 273.15+4, Medium.X_default));
   extends IDEAS.Fluid.BaseCircuits.Interfaces.PartialCircuitBalancingValve;
 
-  //Parameters
+  // Parameters ----------------------------------------------------------------
+
   parameter Real fraKSupply(min=0, max=1) = 0.7
     "Fraction Kv(port_3->port_2)/Kv(port_1->port_2)";
   parameter Real[2] lSupply(each min=0, each max=1) = {0.01, 0.01}
     "Valve leakage, l=Kv(y=0)/Kv(y=1)";
 
-  //Components
+  // Components ----------------------------------------------------------------
+
+protected
   replaceable IDEAS.Fluid.Actuators.BaseClasses.PartialThreeWayValve partialThreeWayValve
   constrainedby IDEAS.Fluid.Actuators.BaseClasses.PartialThreeWayValve(
     redeclare package Medium = Medium,

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialMixingCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialMixingCircuit.mo
@@ -33,6 +33,11 @@ protected
         extent={{-20,-20},{20,20}},
         rotation=270,
         origin={0,104})));
+public
+  Sensors.MassFlowRate senMasFlo annotation (Placement(transformation(
+        extent={{10,-10},{-10,10}},
+        rotation=-90,
+        origin={0,10})));
 equation
   if not measureSupplyT then
     connect(partialThreeWayValve.port_2, port_b1);
@@ -46,12 +51,16 @@ equation
       points={{10,60},{60,60}},
       color={0,127,255},
       smooth=Smooth.None));
-  connect(partialThreeWayValve.port_3, port_a2) annotation (Line(
-      points={{0,50},{0,0},{70,0},{70,-60},{100,-60}},
-      color={0,127,255},
-      smooth=Smooth.None));
   connect(pipeSupply.port_b, partialThreeWayValve.port_1) annotation (Line(
       points={{-70,60},{-10,60}},
+      color={0,127,255},
+      smooth=Smooth.None));
+  connect(partialThreeWayValve.port_3, senMasFlo.port_b) annotation (Line(
+      points={{0,50},{0,20},{1.77636e-015,20}},
+      color={0,127,255},
+      smooth=Smooth.None));
+  connect(senMasFlo.port_a, balancingValve.port_a) annotation (Line(
+      points={{0,0},{0,-20},{60,-20},{60,-60},{10,-60}},
       color={0,127,255},
       smooth=Smooth.None));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
@@ -86,8 +95,9 @@ equation
           origin={0,50},
           rotation=90),
         Line(
-          points={{0,40},{0,0},{60,0},{60,-60}},
-          color={0,0,255},
+          points={{0,40},{0,0},{20,-40},{60,-60}},
+          color={0,0,127},
+          pattern=LinePattern.Dash,
           smooth=Smooth.None)}), Diagram(coordinateSystem(preserveAspectRatio=false,
           extent={{-100,-100},{100,100}}), graphics));
 end PartialMixingCircuit;

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialPumpCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialPumpCircuit.mo
@@ -1,7 +1,8 @@
 within IDEAS.Fluid.BaseCircuits.Interfaces;
 model PartialPumpCircuit
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends PartialFlowCircuit(redeclare Movers.BaseClasses.PartialFlowMachine
       flowRegulator(
         addPowerToMedium=addPowerToMedium));

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialValveCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialValveCircuit.mo
@@ -1,7 +1,8 @@
 within IDEAS.Fluid.BaseCircuits.Interfaces;
 model PartialValveCircuit
 
-  //Extensions
+  // Extensions ----------------------------------------------------------------
+
   extends ValveParametersSupply(
       rhoStdSupply=Medium.density_pTX(101325, 273.15+4, Medium.X_default));
   extends PartialFlowCircuit(redeclare Actuators.BaseClasses.PartialTwoWayValve

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/PartialValveCircuit.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/PartialValveCircuit.mo
@@ -40,7 +40,7 @@ equation
           color={0,255,128},
           smooth=Smooth.None),
         Rectangle(
-          extent={{-4,44},{4,36}},
+          extent={{-6,44},{6,32}},
           lineColor={0,0,127},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid)}));

--- a/IDEAS/Fluid/Production/HP_AirWater.mo
+++ b/IDEAS/Fluid/Production/HP_AirWater.mo
@@ -14,19 +14,24 @@ model HP_AirWater "Modulating air-to-water HP with losses to environment"
 
   Real COP "Instanteanous COP";
 
+  Real modulation(min=0, max=100) = heatSource.modulation
+    "Current modulation percentage";
+
+protected
   IDEAS.Fluid.Production.BaseClasses.HeatSource_HP_AW heatSource(
-    QNom=QNomFinal,
-    TEvaporator=sim.Te,
-    TEnvironment=heatPort.T,
-    UALoss=UALoss,
-    modulation_min=modulation_min,
-    modulation_start=modulation_start,
-    hIn=inStream(port_a.h_outflow),
+    final QNom=QNomFinal,
+    final TEvaporator=sim.Te,
+    final TEnvironment=heatPort.T,
+    final UALoss=UALoss,
+    final modulation_min=modulation_min,
+    final modulation_start=modulation_start,
+    final hIn=inStream(port_a.h_outflow),
     redeclare package Medium = Medium)
     annotation (Placement(transformation(extent={{-60,-16},{-40,4}})));
   outer IDEAS.SimInfoManager sim
     annotation (Placement(transformation(extent={{-82,66},{-62,86}})));
 
+public
   parameter Real modulation_min=20 "Minimal modulation percentage";
   parameter Real modulation_start=35
     "Min estimated modulation level required for start of HP";

--- a/IDEAS/Fluid/Production/HP_AirWater.mo
+++ b/IDEAS/Fluid/Production/HP_AirWater.mo
@@ -1,5 +1,6 @@
 within IDEAS.Fluid.Production;
 model HP_AirWater "Modulating air-to-water HP with losses to environment"
+  import IDEAS;
 
   extends IDEAS.Fluid.Production.Interfaces.PartialDynamicHeaterWithLosses(
       final heaterType=BaseClasses.HeaterType.HP_AW);
@@ -14,7 +15,7 @@ model HP_AirWater "Modulating air-to-water HP with losses to environment"
 
   Real COP "Instanteanous COP";
 
-  Real modulation(min=0, max=100) = heatSource.modulation
+  Real modulation(max=100) = IDEAS.Utilities.Math.Functions.smoothMax(0, heatSource.modulation, 1)
     "Current modulation percentage";
 
 protected

--- a/IDEAS/Fluid/Production/Interfaces/PartialDynamicHeaterWithLosses.mo
+++ b/IDEAS/Fluid/Production/Interfaces/PartialDynamicHeaterWithLosses.mo
@@ -6,10 +6,13 @@ model PartialDynamicHeaterWithLosses
   import IDEAS.Fluid.Production.BaseClasses.HeaterType;
   extends IDEAS.Fluid.Interfaces.TwoPortFlowResistanceParameters(
     final computeFlowResistance=true, dp_nominal = 0);
+
+protected
   extends IDEAS.Fluid.Interfaces.LumpedVolumeDeclarations(T_start=293.15, redeclare
       replaceable package Medium =
         IDEAS.Media.Water.Simple);
 
+public
   parameter HeaterType heaterType
     "Type of the heater, is used mainly for post processing";
   parameter Modelica.SIunits.Power QNom "Nominal power";
@@ -24,6 +27,7 @@ model PartialDynamicHeaterWithLosses
   final parameter Modelica.SIunits.ThermalConductance UALoss=(cDry + mWater*
       Medium.specificHeatCapacityCp(Medium.setState_pTX(Medium.p_default, Medium.T_default,Medium.X_default)))/tauHeatLoss;
 
+protected
   Modelica.Thermal.HeatTransfer.Components.ThermalConductor thermalLosses(G=
         UALoss) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -33,6 +37,8 @@ model PartialDynamicHeaterWithLosses
     "heatPort for thermal losses to environment" annotation (Placement(
         transformation(extent={{-40,-110},{-20,-90}}), iconTransformation(
           extent={{-40,-110},{-20,-90}})));
+
+public
   Modelica.Blocks.Interfaces.RealInput TSet "Temperature setpoint"
                            annotation (Placement(
         transformation(extent={{-126,-20},{-86,20}}), iconTransformation(
@@ -45,9 +51,10 @@ model PartialDynamicHeaterWithLosses
         extent={{-10,-10},{10,10}},
         rotation=-90,
         origin={-74,-100})));
-
   parameter SI.MassFlowRate m_flow_nominal "Nominal mass flow rate";
   parameter SI.Pressure dp_nominal=0 "Pressure";
+
+protected
   IDEAS.Fluid.FixedResistances.Pipe_HeatPort pipe_HeatPort(
     redeclare package Medium = Medium,
     m_flow_nominal=m_flow_nominal,
@@ -71,6 +78,7 @@ model PartialDynamicHeaterWithLosses
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={40,-6})));
+public
   Modelica.Fluid.Interfaces.FluidPort_a port_a(redeclare package Medium =
         Medium) "Fluid inlet"
     annotation (Placement(transformation(extent={{90,-70},{110,-50}})));

--- a/IDEAS/PartialSimInfoManager.mo
+++ b/IDEAS/PartialSimInfoManager.mo
@@ -24,10 +24,13 @@ partial model PartialSimInfoManager
     "put to true if photovoltaics is to be read from files "
     annotation (Dialog(group="Photovoltaics"));
 
+protected
   replaceable IDEAS.Occupants.Extern.Interfaces.Occ_Files occupants
     constrainedby IDEAS.Occupants.Extern.Interfaces.Occ_Files
     "Specifies the files with occupant behavior"
     annotation (Dialog(group="User behaviour", enable=occBeh));
+
+public
   parameter Integer nOcc=33 "Number of occupant profiles to be read"
     annotation (Dialog(group="User behaviour", enable=occBeh));
 
@@ -90,6 +93,7 @@ public
   Real angHou =  (timSol/3600 - 12)*2*Modelica.Constants.pi/24;
   Real angZen = acos(cos(lat)*cos(angDec)*cos(angHou) + sin(lat)*sin(angDec));
 
+protected
   IDEAS.Climate.Time.SimTimes timMan(
     timZonSta=timZonSta,
     lon=lon,

--- a/IDEAS/PartialSimInfoManager.mo
+++ b/IDEAS/PartialSimInfoManager.mo
@@ -168,9 +168,11 @@ protected
   Climate.Meteo.Solar.BaseClasses.SkyClearness
                skyClearness
     annotation (Placement(transformation(extent={{-78,70},{-60,88}})));
+public
   Climate.Meteo.Solar.BaseClasses.SkyBrightnessCoefficients
                             skyBrightnessCoefficients
     annotation (Placement(transformation(extent={{-18,60},{0,78}})));
+protected
   Modelica.Blocks.Sources.RealExpression zenithAngle(y=angZen)
     annotation (Placement(transformation(extent={{-110,46},{-90,66}})));
   Modelica.Blocks.Sources.RealExpression solGloHorIn(y=solGloHor)


### PR DESCRIPTION
I made components protected in the basecircuits, in order to reduce the massive data output. As such, only the fluidports, the parameters and the indicated RealOutputs fro mthe sensors remain visible. To have all information, i added a massflow-sensor in the mixing circuits.

I suggest not to delete the branch after pulling.