### PR TITLE
readMatrix is not defined outside Dymola

### DIFF
--- a/IDEAS/Fluid/HeatExchangers/GroundHeatExchangers/Borefield/BaseClasses/Scripts/initializeModel.mo
+++ b/IDEAS/Fluid/HeatExchangers/GroundHeatExchangers/Borefield/BaseClasses/Scripts/initializeModel.mo
@@ -48,7 +48,7 @@ algorithm
     existShoTerRes := true;
   end if;
 
-  TResSho := readMatrix(
+  TResSho := ExternData.Functions.readMatrix(
     fileName=pathSave + "ShoTermData.mat",
     matrixName="TResSho",
     rows=1,

--- a/IDEAS/Fluid/HeatExchangers/GroundHeatExchangers/Borefield/BaseClasses/Scripts/saveAggregationMatrix.mo
+++ b/IDEAS/Fluid/HeatExchangers/GroundHeatExchangers/Borefield/BaseClasses/Scripts/saveAggregationMatrix.mo
@@ -72,7 +72,7 @@ The borefield model with this BfData record has not yet been initialized. Please
      + fil.pathMod + "()," + "gen=" + gen.pathMod + "())" + "\n
 ************************************************************************************************************************ \n ");
 
-  TResSho := readMatrix(
+  TResSho := ExternData.Functions.readMatrix(
     fileName=pathSave + "ShoTermData.mat",
     matrixName="TResSho",
     rows=1,
@@ -113,14 +113,14 @@ The borefield model with this BfData record has not yet been initialized. Please
     existAgg := true;
     writeAgg := false;
 
-    mat := readMatrix(
+    mat := ExternData.Functions.readMatrix(
       fileName=pathSave + "TWallSteSta.mat",
       matrixName="TWallSteSta",
       rows=1,
       columns=1);
     TWallSteSta := mat[1, 1];
 
-    kappaMat := readMatrix(
+    kappaMat := ExternData.Functions.readMatrix(
       fileName=pathSave + "Agg" + String(lenSim) + ".mat",
       matrixName="kappaMat",
       rows=q_max,

--- a/IDEAS/package.mo
+++ b/IDEAS/package.mo
@@ -26,15 +26,14 @@ import SI = Modelica.SIunits;
 
 
 annotation (
-  uses(Modelica(version="3.2.1")),
-  Icon(graphics),
+  uses(Modelica(version="3.2.1"), ExternData(version="2.0.0")),
   version="0.2",
   conversion(noneFromVersion="", noneFromVersion="1"),
   Documentation(info="<html>
 <p>Licensed by KU Leuven and 3E under the Modelica License 2 </p>
 <p>Copyright &copy; 2013-2023, KU Leuven and 3E. </p>
 <p>&nbsp; </p>
-<p><i>This Modelica package is <u>free</u> software and the use is completely at <u>your own risk</u>;</i>  <i>it can be redistributed and/or modified under the terms of the Modelica License 2. </i></p>
-<p><i>For license conditions (including the disclaimer of warranty) see <a href=\"UrlBlockedError.aspx\">Modelica.UsersGuide.ModelicaLicense2</a> or visit <a href=\"https://www.modelica.org/licenses/ModelicaLicense2\">https://www.modelica.org/licenses/ModelicaLicense2</a>.</i> </p>
+<p><i>This Modelica package is <u>free</u> software and the use is completely at <u>your own risk</u>;</i>  <i>it can be redistributed and/or modified under the terms of the Modelica License 2.</i></p>
+<p><i>For license conditions (including the disclaimer of warranty) see <a href=\"UrlBlockedError.aspx\">Modelica.UsersGuide.ModelicaLicense2</a> or visit <a href=\"https://www.modelica.org/licenses/ModelicaLicense2\">https://www.modelica.org/licenses/ModelicaLicense2</a>.</i></p>
 </html>"));
 end IDEAS;


### PR DESCRIPTION
Use ExternData.Functions.readMatrix instead

Sure it does to deal with writeMatrix, too, which just is not yet implemented. It likely will follow soon.

Please also notice that [ExternData](https://github.com/tbeu/ExternData) v2.0.0 is not yet released. This PR is just to check if you are generally interested to substitute Dymola built-in functions by a FOSS implementation.