### PR TITLE
Bugfix

### DIFF
--- a/IDEAS/Fluid/BaseCircuits/CollectorUnit.mo
+++ b/IDEAS/Fluid/BaseCircuits/CollectorUnit.mo
@@ -6,7 +6,7 @@ model CollectorUnit "Collector unit"
     annotation (__Dymola_choicesAllMatching=true);
 
   //Extensions
-  extends IDEAS.Fluid.Interfaces.FourPort(
+  extends IDEAS.Fluid.Interfaces.PartialFourPort(
     redeclare package Medium1 = Medium,
     redeclare package Medium2 = Medium,
     final allowFlowReversal1 = allowFlowReversal,
@@ -25,14 +25,14 @@ model CollectorUnit "Collector unit"
   Modelica.Fluid.Interfaces.FluidPort_a port_a3(
                      redeclare final package Medium = Medium,
                      m_flow(min=if allowFlowReversal1 then -Modelica.Constants.inf else 0),
-                     h_outflow(start=h_outflow_a1_start))
+                     h_outflow(start=Medium.h_default))
     "Fluid connector a1 (positive design flow direction is from port_a1 to port_b1)"
     annotation (Placement(transformation(extent={{50,90},{70,110}},
             rotation=0)));
   Modelica.Fluid.Interfaces.FluidPort_b port_b3(
                      redeclare final package Medium = Medium,
                      m_flow(max=if allowFlowReversal2 then +Modelica.Constants.inf else 0),
-                     h_outflow(start=h_outflow_b2_start))
+                     h_outflow(start=Medium.h_default))
     "Fluid connector b2 (positive design flow direction is from port_a2 to port_b2)"
     annotation (Placement(transformation(extent={{-50,90},{-70,110}},
                           rotation=0),

--- a/IDEAS/Fluid/BaseCircuits/Interfaces/CircuitInterface.mo
+++ b/IDEAS/Fluid/BaseCircuits/Interfaces/CircuitInterface.mo
@@ -6,7 +6,7 @@ partial model CircuitInterface "Partial circuit for base circuits"
     annotation (__Dymola_choicesAllMatching=true);
 
   //Extensions
-  extends IDEAS.Fluid.Interfaces.FourPort(
+  extends IDEAS.Fluid.Interfaces.PartialFourPort(
     redeclare package Medium1 = Medium,
     redeclare package Medium2 = Medium,
     final allowFlowReversal1 = allowFlowReversal,

--- a/IDEAS/Fluid/FixedResistances/SplitterFixedResistanceDpM.mo
+++ b/IDEAS/Fluid/FixedResistances/SplitterFixedResistanceDpM.mo
@@ -4,7 +4,6 @@ model SplitterFixedResistanceDpM
     extends IDEAS.Fluid.BaseClasses.PartialThreeWayResistance(
     mDyn_flow_nominal = sum(abs(m_flow_nominal[:])/3),
       redeclare IDEAS.Fluid.FixedResistances.FixedResistanceDpM res1(
-         redeclare package Medium=Medium,
             final allowFlowReversal=true,
             from_dp=from_dp,
             final m_flow_nominal=m_flow_nominal[1],
@@ -15,7 +14,6 @@ model SplitterFixedResistanceDpM
             homotopyInitialization=homotopyInitialization,
             deltaM=deltaM),
       redeclare IDEAS.Fluid.FixedResistances.FixedResistanceDpM res2(
-         redeclare package Medium=Medium,
             final allowFlowReversal=true,
             from_dp=from_dp,
             final m_flow_nominal=m_flow_nominal[2],
@@ -26,7 +24,6 @@ model SplitterFixedResistanceDpM
             homotopyInitialization=homotopyInitialization,
             deltaM=deltaM),
       redeclare IDEAS.Fluid.FixedResistances.FixedResistanceDpM res3(
-         redeclare package Medium=Medium,
             final allowFlowReversal=true,
             from_dp=from_dp,
             final m_flow_nominal=m_flow_nominal[3],


### PR DESCRIPTION
Two bug fixes:

- Dependency of PartialFourPort in Fluid.BaseClasses
- Propagation of Medium in IDEAS.Fluid.FixedResistances.SplitterFixedResistanceDpM, this should actually also be a bug in Annex60 if merged correctly, @Mathadon.