### PR TITLE
EnergyDynamics propagated from MonoLayer to MonoLayerDyn in MonoLayer.mo

### DIFF
--- a/IDEAS/Buildings/Components/BaseClasses/MonoLayer.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/MonoLayer.mo
@@ -39,7 +39,8 @@ model MonoLayer "single material layer"
     A=A,
     mat=mat,
     T_start=T_start,
-    placeCapacityAtSurf_b=placeCapacityAtSurf_b) if
+    placeCapacityAtSurf_b=placeCapacityAtSurf_b,
+    energyDynamics=energyDynamics) if
                             dynamicLayer and realLayer and not airLayer
     "Dynamic monolayer for solid"
     annotation (Placement(transformation(extent={{-10,-42},{10,-22}})));

--- a/IDEAS/Buildings/Components/BoundaryWall.mo
+++ b/IDEAS/Buildings/Components/BoundaryWall.mo
@@ -2,8 +2,11 @@ within IDEAS.Buildings.Components;
 model BoundaryWall "Opaque wall with boundary conditions"
   extends IDEAS.Buildings.Components.Interfaces.PartialOpaqueSurface(
      final QTra_design=U_value*AWall*(273.15 + 21 - TRef_a),
-     dT_nominal_a=-1);
-
+     dT_nominal_a=-1,
+    layMul(energyDynamics=energyDynamics));
+  parameter Modelica.Fluid.Types.Dynamics energyDynamics= if use_T_in then Modelica.Fluid.Types.Dynamics.DynamicFreeInitial else  Modelica.Fluid.Types.Dynamics.FixedInitial
+    "Static (steady state) or transient (dynamic) thermal conduction model"
+    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Boolean use_T_in = false
     "Get the boundary temperature from the input connector";
   parameter Boolean use_Q_in = false


### PR DESCRIPTION
Fixed issue461

- EnergyDynamics propagated to monoLayer
- Parameter for EnergyDynamics included for BoundaryWall.mo  Added conditional declaration for use_T_in to make sure free initial conditions are used.

Passed all unit tests