### PR TITLE
make weaDatBus public such that it can be connected to models from bu…

### DIFF
--- a/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
+++ b/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
@@ -25,12 +25,13 @@ model Adsolair58 "Adsolair58 example model"
   IDEAS.Fluid.Sources.Boundary_pT env(
     redeclare package Medium = Medium,
     use_T_in=true,
-    use_X_in=true,
-    nPorts=2) "Environment"
+    nPorts=2,
+    use_Xi_in=true)
+              "Environment"
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
 
-  Modelica.Blocks.Sources.RealExpression reaExpXw[2](y={sim.XiEnv.X[1],1 - sim.XiEnv.X[
-        1]}) "For setting humidity of inlet air"
+  Modelica.Blocks.Sources.RealExpression reaExpXw(y=sim.XiEnv.X[1])
+    "For setting humidity of inlet air"
     annotation (Placement(transformation(extent={{-112,26},{-92,46}})));
   Modelica.Blocks.Sources.Constant dpNom[2](each k=dp_nominal)
     annotation (Placement(transformation(extent={{14,60},{0,74}})));
@@ -190,8 +191,6 @@ model Adsolair58 "Adsolair58 example model"
   Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient temperature"
     annotation (Placement(transformation(extent={{-112,40},{-92,60}})));
 equation
-  connect(reaExpXw.y, env.X_in)
-    annotation (Line(points={{-91,36},{-86.5,36},{-82,36}}, color={0,0,127}));
   connect(env.ports[1], adsolair58.port_b1) annotation (Line(points={{-60,42},{-56,
           42},{-52,42},{-52,46},{-40,46}}, color={0,127,255}));
   connect(env.ports[2], adsolair58.port_a2) annotation (Line(points={{-60,38},{-52,
@@ -304,6 +303,8 @@ equation
     annotation (Line(points={{-22,26},{-22,30}}, color={0,127,255}));
   connect(Te.y, env.T_in) annotation (Line(points={{-91,50},{-86,50},{-86,44},{-82,
           44}}, color={0,0,127}));
+  connect(reaExpXw.y, env.Xi_in[1])
+    annotation (Line(points={{-91,36},{-82,36}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-120},
             {100,100}})),                                        Diagram(
         coordinateSystem(preserveAspectRatio=false, extent={{-100,-120},{100,100}})),

--- a/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
+++ b/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
@@ -28,13 +28,10 @@ model Adsolair58 "Adsolair58 example model"
     use_X_in=true,
     nPorts=2) "Environment"
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
-  IDEAS.Buildings.Components.Interfaces.WeaBus weaBus1(numSolBus=sim.numIncAndAziInBus,
-      outputAngles=sim.outputAngles)
-    annotation (Placement(transformation(extent={{-74,82},{-54,102}})));
 
   Modelica.Blocks.Routing.RealPassThrough X_w;
-  Modelica.Blocks.Sources.RealExpression reaExpXw[2](y={X_w.y,1 - X_w.y})
-    "For setting humidity of inlet air"
+  Modelica.Blocks.Sources.RealExpression reaExpXw[2](y={sim.XiEnv.X[1],1 - sim.XiEnv.X[
+        1]}) "For setting humidity of inlet air"
     annotation (Placement(transformation(extent={{-112,26},{-92,46}})));
   Modelica.Blocks.Sources.Constant dpNom[2](each k=dp_nominal)
     annotation (Placement(transformation(extent={{14,60},{0,74}})));
@@ -191,20 +188,9 @@ model Adsolair58 "Adsolair58 example model"
   Modelica.Blocks.Sources.Constant TSet(each k=273.15 + 22)
     "Temperature set point of the zone"
     annotation (Placement(transformation(extent={{130,-80},{116,-66}})));
+  Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient temperature"
+    annotation (Placement(transformation(extent={{-112,40},{-92,60}})));
 equation
-  connect(sim.weaBus, weaBus1) annotation (Line(
-      points={{-84,92.8},{-74,92.8},{-74,96},{-64,96},{-64,92}},
-      color={255,204,51},
-      thickness=0.5), Text(
-      string="%second",
-      index=1,
-      extent={{6,3},{6,3}}));
-  connect(env.T_in, weaBus1.Te) annotation (Line(points={{-82,44},{-96,44},{-96,
-          72},{-63.95,72},{-63.95,92.05}}, color={0,0,127}), Text(
-      string="%second",
-      index=1,
-      extent={{6,3},{6,3}}));
-  connect(X_w.u, weaBus1.X_wEnv);
   connect(reaExpXw.y, env.X_in)
     annotation (Line(points={{-91,36},{-86.5,36},{-82,36}}, color={0,0,127}));
   connect(env.ports[1], adsolair58.port_b1) annotation (Line(points={{-60,42},{-56,

--- a/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
+++ b/IDEAS/Airflow/AHU/Examples/Adsolair58.mo
@@ -29,7 +29,6 @@ model Adsolair58 "Adsolair58 example model"
     nPorts=2) "Environment"
     annotation (Placement(transformation(extent={{-80,30},{-60,50}})));
 
-  Modelica.Blocks.Routing.RealPassThrough X_w;
   Modelica.Blocks.Sources.RealExpression reaExpXw[2](y={sim.XiEnv.X[1],1 - sim.XiEnv.X[
         1]}) "For setting humidity of inlet air"
     annotation (Placement(transformation(extent={{-112,26},{-92,46}})));
@@ -303,6 +302,8 @@ equation
     annotation (Line(points={{-36,6},{-22,6},{-22,10}}, color={0,127,255}));
   connect(pum.port_b, adsolair58.port_a)
     annotation (Line(points={{-22,26},{-22,30}}, color={0,127,255}));
+  connect(Te.y, env.T_in) annotation (Line(points={{-91,50},{-86,50},{-86,44},{-82,
+          44}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-120},
             {100,100}})),                                        Diagram(
         coordinateSystem(preserveAspectRatio=false, extent={{-100,-120},{100,100}})),

--- a/IDEAS/BoundaryConditions/Interfaces/PartialSimInfoManager.mo
+++ b/IDEAS/BoundaryConditions/Interfaces/PartialSimInfoManager.mo
@@ -127,10 +127,16 @@ protected
     annotation (Placement(transformation(extent={{60,-58},{80,-38}})));
 
 
+  // Icon of weaBus is made very small as it is not intended that a user would use it.
+  // weaBus is still directly connected in the zone model and the connector should
+  // therefore not be protected.
+  // Connector weaDatBus is made available for the user and it should be used instead
+  // of weaBus.
 public
   Buildings.Components.Interfaces.WeaBus weaBus(numSolBus=numIncAndAziInBus,
       final outputAngles=outputAngles)
-    annotation (Placement(transformation(extent={{90,30},{110,50}})));
+    annotation (Placement(transformation(extent={{90,30},{110,50}}),
+        iconTransformation(extent={{90,30},{90,30}})));
   SolarIrradiation.ShadedRadSol[numIncAndAziInBus] radSol(
     inc=incAndAziInBus[:, 1],
     azi=incAndAziInBus[:, 2],
@@ -168,6 +174,12 @@ public
     "Bus for windows in case of linearisation";
   Modelica.Blocks.Routing.RealPassThrough solTim "Solar time"
     annotation (Placement(transformation(extent={{-86,-2},{-78,6}})));
+  WeatherData.Bus weaDatBus "Weather data bus connectable to weaBus connector from Buildings Library"
+    annotation (Placement(transformation(extent={{-110,-20},{-90,0}}),
+        iconTransformation(
+        extent={{-20,-19},{20,19}},
+        rotation=270,
+        origin={99,3.55271e-015})));
 protected
   Modelica.Blocks.Routing.RealPassThrough solHouAng "Solar hour angle"
     annotation (Placement(transformation(extent={{-86,66},{-78,74}})));
@@ -188,9 +200,6 @@ protected
     "Diffuse solar irradiation on a horizontal plane"
     annotation (Placement(transformation(extent={{-86,94},{-78,102}})));
 
-  WeatherData.Bus weaBus1
-             "Weather data bus"
-    annotation (Placement(transformation(extent={{-110,50},{-90,70}})));
 initial equation
   Etot = 0;
 equation
@@ -339,32 +348,30 @@ equation
           110},{-70,98},{-77.6,98}},color={0,0,127}));
   connect(skyClearness.HGloHor,HGloHor. y) annotation (Line(points={{-62,116},{-72,
           116},{-72,112},{-77.6,112}},color={0,0,127}));
-  connect(solTim.u,weaBus1. solTim) annotation (Line(points={{-86.8,2},{-100,2},
-          {-100,60}},color={0,0,127}));
-  connect(angZen.u, weaBus1.solZen) annotation (Line(points={{-86.8,84},{-100,84},
-          {-100,60}}, color={0,0,127}));
-  connect(HDifHor.u,weaBus1. HDifHor)
-    annotation (Line(points={{-86.8,98},{-100,98},{-100,60}},
-                                                            color={0,0,127}));
-  connect(HGloHor.u,weaBus1. HGloHor) annotation (Line(points={{-86.8,112},{-100,
-          112},{-100,60}},color={0,0,127}));
-  connect(HDirNor.u,weaBus1. HDirNor)
-    annotation (Line(points={{-86.8,44},{-100,44},{-100,60}},
-                                                            color={0,0,127}));
-  connect(solDec.u,weaBus1. solDec)
-    annotation (Line(points={{-86.8,56},{-100,56},{-100,60}},
-                                                            color={0,0,127}));
-  connect(solHouAng.u,weaBus1. solHouAng)
-    annotation (Line(points={{-86.8,70},{-100,70},{-100,60}},
-                                                            color={0,0,127}));
-  connect(TDryBul.u,weaBus1. TDryBul)
-    annotation (Line(points={{-86.8,30},{-100,30},{-100,60}},
-                                                            color={0,0,127}));
-  connect(phiEnv.u,weaBus1. relHum)
-    annotation (Line(points={{-86.8,16},{-100,16},{-100,60}},
-                                                          color={0,0,127}));
-  connect(weaDat.weaBus, weaBus1) annotation (Line(
-      points={{-80,-50},{-80,-40},{-100,-40},{-100,60}},
+  connect(solTim.u, weaDatBus.solTim)
+    annotation (Line(points={{-86.8,2},{-100,2},{-100,-10}},color={0,0,127}));
+  connect(angZen.u, weaDatBus.solZen) annotation (Line(points={{-86.8,84},{-100,
+          84},{-100,-10}},color={0,0,127}));
+  connect(HDifHor.u, weaDatBus.HDifHor) annotation (Line(points={{-86.8,98},{
+          -100,98},{-100,-10}},
+                          color={0,0,127}));
+  connect(HGloHor.u, weaDatBus.HGloHor) annotation (Line(points={{-86.8,112},{
+          -100,112},{-100,-10}},
+                           color={0,0,127}));
+  connect(HDirNor.u, weaDatBus.HDirNor) annotation (Line(points={{-86.8,44},{
+          -100,44},{-100,-10}},
+                          color={0,0,127}));
+  connect(solDec.u, weaDatBus.solDec) annotation (Line(points={{-86.8,56},{-100,
+          56},{-100,-10}},color={0,0,127}));
+  connect(solHouAng.u, weaDatBus.solHouAng) annotation (Line(points={{-86.8,70},
+          {-100,70},{-100,-10}},color={0,0,127}));
+  connect(TDryBul.u, weaDatBus.TDryBul) annotation (Line(points={{-86.8,30},{
+          -100,30},{-100,-10}},
+                          color={0,0,127}));
+  connect(phiEnv.u, weaDatBus.relHum) annotation (Line(points={{-86.8,16},{-100,
+          16},{-100,-10}},color={0,0,127}));
+  connect(weaDat.weaBus, weaDatBus) annotation (Line(
+      points={{-80,-50},{-80,-40},{-80,-10},{-100,-10}},
       color={255,204,51},
       thickness=0.5));
   connect(TDryBul.y, weaBus.Te) annotation (Line(points={{-77.6,30},{100.05,30},
@@ -452,6 +459,13 @@ equation
     Documentation(info="<html>
 </html>", revisions="<html>
 <ul>
+<li>
+June 21, 2018, by Damien Picard:<br/>
+Reduce the icon size of weaBus to something very small such that users would
+not try to connect to it.
+Rename and make public the connector weaDatBus such that it can be connected 
+to models from the Buildings library.
+</li>
 <li>
 June 12, 2018, by Filip Jorissen:<br/>
 Refactored implementation such that we use more computations from the weather

--- a/IDEAS/BoundaryConditions/SimInfoManager.mo
+++ b/IDEAS/BoundaryConditions/SimInfoManager.mo
@@ -1,7 +1,8 @@
 within IDEAS.BoundaryConditions;
 model SimInfoManager
   "Simulation information manager for handling time and climate data required in each for simulation."
-  extends BoundaryConditions.Interfaces.PartialSimInfoManager;
+  extends BoundaryConditions.Interfaces.PartialSimInfoManager(weaBus(numSolBus=
+          numIncAndAziInBus));
 
 protected
   Modelica.Blocks.Routing.RealPassThrough HDirNorData;
@@ -22,15 +23,23 @@ equation
   Tsky = TBlaSkyData.y;
   Va = winSpeData.y;
 
-  connect(HDirNorData.u, weaBus1.HDirNor);
-  connect(HGloHorData.u, weaBus1.HGloHor);
-  connect(HDiffHorData.u, weaBus1.HDifHor);
-  connect(TDryBulData.u, weaBus1.TDryBul);
-  connect(relHumData.u, weaBus1.relHum);
-  connect(TDewPoiData.u, weaBus1.TDewPoi);
-  connect(nOpaData.u, weaBus1.nOpa);
-  connect(winSpeData.u, weaBus1.winSpe);
-  connect(TBlaSkyData.u, weaBus1.TBlaSky);
+  connect(HDirNorData.u, weaDatBus.HDirNor);
+  connect(HGloHorData.u, weaDatBus.HGloHor);
+  connect(HDiffHorData.u, weaDatBus.HDifHor);
+  connect(TDryBulData.u, weaDatBus.TDryBul);
+  connect(relHumData.u, weaDatBus.relHum);
+  connect(TDewPoiData.u, weaDatBus.TDewPoi);
+  connect(nOpaData.u, weaDatBus.nOpa);
+  connect(winSpeData.u, weaDatBus.winSpe);
+  connect(TBlaSkyData.u, weaDatBus.TBlaSky);
+  connect(weaDatBus, weaBus.weaBus) annotation (Line(
+      points={{-100,-10},{2,-10},{100.05,-10},{100.05,40.05}},
+      color={255,204,51},
+      thickness=0.5,
+      visible=false), Text(
+      string="%first",
+      index=-1,
+      extent={{-6,3},{-6,3}}));
   annotation (
     defaultComponentName="sim",
     defaultComponentPrefixes="inner",

--- a/IDEAS/BoundaryConditions/SimInfoManager.mo
+++ b/IDEAS/BoundaryConditions/SimInfoManager.mo
@@ -1,8 +1,7 @@
 within IDEAS.BoundaryConditions;
 model SimInfoManager
   "Simulation information manager for handling time and climate data required in each for simulation."
-  extends BoundaryConditions.Interfaces.PartialSimInfoManager(weaBus(numSolBus=
-          numIncAndAziInBus));
+  extends BoundaryConditions.Interfaces.PartialSimInfoManager;
 
 protected
   Modelica.Blocks.Routing.RealPassThrough HDirNorData;
@@ -32,14 +31,6 @@ equation
   connect(nOpaData.u, weaDatBus.nOpa);
   connect(winSpeData.u, weaDatBus.winSpe);
   connect(TBlaSkyData.u, weaDatBus.TBlaSky);
-  connect(weaDatBus, weaBus.weaBus) annotation (Line(
-      points={{-100,-10},{2,-10},{100.05,-10},{100.05,40.05}},
-      color={255,204,51},
-      thickness=0.5,
-      visible=false), Text(
-      string="%first",
-      index=-1,
-      extent={{-6,3},{-6,3}}));
   annotation (
     defaultComponentName="sim",
     defaultComponentPrefixes="inner",

--- a/IDEAS/Buildings/Components/BaseClasses/ConvectiveHeatTransfer/Examples/Convection.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/ConvectiveHeatTransfer/Examples/Convection.mo
@@ -29,8 +29,6 @@ model Convection "Convection model tests"
     inc=IDEAS.Types.Tilt.Floor,
     d=0.1) "Mono layer air model for horizontal inclination"
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
-  Interfaces.WeaBus weaBus1(numSolBus=sim.numIncAndAziInBus)
-    annotation (Placement(transformation(extent={{-80,82},{-60,102}})));
   Modelica.Blocks.Sources.Ramp ramp(
     height=-20,
     duration=1e6,
@@ -57,6 +55,11 @@ model Convection "Convection model tests"
     linearise=true)
     "Mono layer air model for horizontal inclination: linearised"
     annotation (Placement(transformation(extent={{-20,-30},{0,-10}})));
+  Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient temperature"
+    annotation (Placement(transformation(extent={{-62,-84},{-42,-64}})));
+  Modelica.Blocks.Sources.RealExpression hConExt(y=sim.hCon)
+    "Exterior convection"
+    annotation (Placement(transformation(extent={{-62,-98},{-42,-78}})));
 equation
   connect(monLayAirWal.port_b, fixTem.port)
     annotation (Line(points={{0,22},{0,0},{40,0}}, color={191,0,0}));
@@ -66,14 +69,6 @@ equation
     annotation (Line(points={{-40,0},{-20,0}}, color={191,0,0}));
   connect(monLayAirHor.port_a, monLayAirWal.port_a)
     annotation (Line(points={{-20,0},{-20,22}}, color={191,0,0}));
-  connect(sim.weaBus, weaBus1) annotation (Line(
-      points={{-84,92.8},{-78,92.8},{-78,92},{-70,92}},
-      color={255,204,51},
-      thickness=0.5));
-  connect(extCon.hConExt, weaBus1.hConExt) annotation (Line(points={{-20,-79},{
-          -70,-79},{-70,-76},{-70,8},{-69.95,8},{-69.95,92.05}}, color={0,0,127}));
-  connect(extCon.Te, weaBus1.Te) annotation (Line(points={{-20,-74.8},{-70,
-          -74.8},{-70,-74},{-69.95,-74},{-69.95,92.05}}, color={0,0,127}));
   connect(ramp.y, preTem.T)
     annotation (Line(points={{-79,0},{-62,0}}, color={0,0,127}));
   connect(intConVerLin.port_a, intConFlo.port_a)
@@ -86,10 +81,6 @@ equation
     annotation (Line(points={{0,92},{0,72},{0,72}}, color={191,0,0}));
   connect(intConFlo.port_b, monLayAirWal.port_b)
     annotation (Line(points={{0,52},{0,22}}, color={191,0,0}));
-  connect(extConLin.hConExt, extCon.hConExt) annotation (Line(points={{-20,-99},
-          {-70,-99},{-70,-100},{-70,-79},{-20,-79}}, color={0,0,127}));
-  connect(extConLin.Te, extCon.Te) annotation (Line(points={{-20,-94.8},{-70,
-          -94.8},{-70,-74.8},{-20,-74.8}}, color={0,0,127}));
   connect(extConLin.port_a, extCon.port_a)
     annotation (Line(points={{-20,-90},{-20,-90},{-20,-70}}, color={191,0,0}));
   connect(intConFlo.port_b, intConVerLin.port_b)
@@ -100,6 +91,14 @@ equation
     annotation (Line(points={{-20,-20},{-20,0}}, color={191,0,0}));
   connect(extCon.port_a, monLayAirHorLin.port_a)
     annotation (Line(points={{-20,-70},{-20,-20}}, color={191,0,0}));
+  connect(Te.y, extCon.Te) annotation (Line(points={{-41,-74},{-20,-74},{-20,
+          -74.8}}, color={0,0,127}));
+  connect(Te.y, extConLin.Te) annotation (Line(points={{-41,-74},{-34,-74},{-34,
+          -94.8},{-20,-94.8}}, color={0,0,127}));
+  connect(hConExt.y, extCon.hConExt) annotation (Line(points={{-41,-88},{-34,
+          -88},{-26,-88},{-26,-79},{-20,-79}}, color={0,0,127}));
+  connect(hConExt.y, extConLin.hConExt) annotation (Line(points={{-41,-88},{-26,
+          -88},{-26,-99},{-20,-99}}, color={0,0,127}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     experiment(

--- a/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlowBoundary.mo
+++ b/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlowBoundary.mo
@@ -3,8 +3,7 @@ partial model PartialInterzonalAirFlowBoundary
   "Partial interzonal air flow model that includes a boundary"
   extends
     IDEAS.Buildings.Components.InterzonalAirFlow.BaseClasses.PartialInterzonalAirFlow;
-  outer BoundaryConditions.SimInfoManager       sim
-    "Simulation information manager"
+  outer BoundaryConditions.SimInfoManager sim "Simulation information manager"
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
   Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow preHeaFlo(final
       alpha=0) if                                                                 sim.computeConservationOfEnergy
@@ -21,14 +20,20 @@ partial model PartialInterzonalAirFlowBoundary
     use_T_in=true,
     use_p_in=false,
     use_C_in=Medium.nC == 1,
-    use_Xi_in=Medium.nX == 2)
-                             annotation (Placement(transformation(
+    use_Xi_in=Medium.nX == 2) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={0,10})));
 protected
   Interfaces.WeaBus weaBus(numSolBus=sim.numIncAndAziInBus, outputAngles=sim.outputAngles)
     annotation (Placement(transformation(extent={{-50,82},{-30,102}})));
+public
+  Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient temperature"
+    annotation (Placement(transformation(extent={{-44,52},{-26,68}})));
+  Modelica.Blocks.Sources.RealExpression Xi(y=sim.XiEnv.X[1])
+    annotation (Placement(transformation(extent={{-44,64},{-26,80}})));
+  Modelica.Blocks.Sources.RealExpression CEnv(y=sim.CEnv.y)
+    annotation (Placement(transformation(extent={{-44,74},{-26,90}})));
 equation
   connect(port_a_interior, port_b_exterior) annotation (Line(points={{-60,-100},
           {-60,0},{-20,0},{-20,100}}, color={0,127,255}));
@@ -38,21 +43,18 @@ equation
     annotation (Line(points={{-90,76},{-90,80}}, color={191,0,0}));
   connect(QGai.y, preHeaFlo.Q_flow)
     annotation (Line(points={{-85,40},{-90,40},{-90,56}}, color={0,0,127}));
-  connect(sim.weaBus,weaBus)  annotation (Line(
-      points={{-84,92.8},{-40,92.8},{-40,92}},
-      color={255,204,51},
-      thickness=0.5));
+
 
   if Medium.nX == 2 then
-    connect(bou.Xi_in[1], weaBus.X_wEnv) annotation (Line(points={{4,22},{4,92.05},
-        {-39.95,92.05}}, color={0,0,127}));
+    connect(bou.Xi_in[1], Xi.y) annotation (Line(points={{4,22},{4,72},{-25.1,
+            72}},            color={0,0,127}));
   end if;
   if Medium.nC == 1 then
-    connect(bou.C_in[1], weaBus.CEnv) annotation (Line(points={{8,22},{8,92.05},
-          {-39.95,92.05}},                            color={0,0,127}));
+    connect(bou.C_in[1], CEnv.y) annotation (Line(points={{8,22},{8,82},{-25.1,
+            82}},            color={0,0,127}));
   end if;
-  connect(bou.T_in, weaBus.Te) annotation (Line(points={{-4,22},{-4,92.05},{-39.95,
-          92.05}}, color={0,0,127}));
+  connect(bou.T_in, Te.y) annotation (Line(points={{-4,22},{-4,60},{-25.1,60}},
+                   color={0,0,127}));
 
   annotation (Documentation(revisions="<html>
 <ul>

--- a/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlowBoundary.mo
+++ b/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlowBoundary.mo
@@ -5,6 +5,7 @@ partial model PartialInterzonalAirFlowBoundary
     IDEAS.Buildings.Components.InterzonalAirFlow.BaseClasses.PartialInterzonalAirFlow;
   outer BoundaryConditions.SimInfoManager sim "Simulation information manager"
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+protected
   Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow preHeaFlo(final
       alpha=0) if                                                                 sim.computeConservationOfEnergy
     "Prescribed heat flow rate for conservation of energy check" annotation (
@@ -24,10 +25,7 @@ partial model PartialInterzonalAirFlowBoundary
         extent={{10,-10},{-10,10}},
         rotation=90,
         origin={0,10})));
-protected
-  Interfaces.WeaBus weaBus(numSolBus=sim.numIncAndAziInBus, outputAngles=sim.outputAngles)
-    annotation (Placement(transformation(extent={{-50,82},{-30,102}})));
-public
+
   Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient temperature"
     annotation (Placement(transformation(extent={{-44,52},{-26,68}})));
   Modelica.Blocks.Sources.RealExpression Xi(y=sim.XiEnv.X[1])

--- a/IDEAS/Examples/PPD12/Heating.mo
+++ b/IDEAS/Examples/PPD12/Heating.mo
@@ -521,13 +521,6 @@ equation
                                                color={191,0,0}));
   connect(radGnd.port_a, valGnd.port_b) annotation (Line(points={{-40,-160},{-40,
           -150}},            color={0,127,255}));
-  connect(sim.weaBus, weaBus1) annotation (Line(
-      points={{384,50.8},{380,50.8},{380,80}},
-      color={255,204,51},
-      thickness=0.5), Text(
-      string="%second",
-      index=1,
-      extent={{6,3},{6,3}}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -200},{400,240}},
         initialScale=0.1), graphics={

--- a/IDEAS/Examples/PPD12/Structure.mo
+++ b/IDEAS/Examples/PPD12/Structure.mo
@@ -349,9 +349,6 @@ model Structure "Ppd 12 example model"
     inc=IDEAS.Types.Tilt.Floor)
     "Dummy for representing stairway connection between floors"
     annotation (Placement(transformation(extent={{182,-22},{192,-2}})));
-  Buildings.Components.Interfaces.WeaBus weaBus1(numSolBus=sim.numIncAndAziInBus,
-      outputAngles=sim.outputAngles)
-    annotation (Placement(transformation(extent={{370,70},{390,90}})));
 equation
   connect(hallway.proBusD, living.proBusB) annotation (Line(
       points={{-73,50},{-45,50},{-45,40}},
@@ -453,13 +450,6 @@ equation
       points={{182.833,-10},{76.2,-10},{76.2,10}},
       color={255,204,51},
       thickness=0.5));
-  connect(sim.weaBus, weaBus1) annotation (Line(
-      points={{384,50.8},{380,50.8},{380,80}},
-      color={255,204,51},
-      thickness=0.5), Text(
-      string="%second",
-      index=1,
-      extent={{6,3},{6,3}}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -200},{400,240}},
         initialScale=0.1), graphics={

--- a/IDEAS/Examples/PPD12/Ventilation.mo
+++ b/IDEAS/Examples/PPD12/Ventilation.mo
@@ -89,6 +89,8 @@ model Ventilation "Ppd 12 example model"
     dp1_nominal=65,
     dp2_nominal=225) "Heat recovery unit"
     annotation (Placement(transformation(extent={{290,150},{310,170}})));
+  Modelica.Blocks.Sources.RealExpression Te(y=sim.Te) "Ambient air"
+    annotation (Placement(transformation(extent={{374,130},{394,150}})));
 equation
   connect(hallway.proBusD, living.proBusB) annotation (Line(
       points={{-73,50},{-45,50},{-45,40}},
@@ -190,15 +192,6 @@ equation
       points={{182.833,-10},{76.2,-10},{76.2,10}},
       color={255,204,51},
       thickness=0.5));
-  connect(sim.weaBus, weaBus1) annotation (Line(
-      points={{384,50.8},{380,50.8},{380,80}},
-      color={255,204,51},
-      thickness=0.5), Text(
-      string="%second",
-      index=1,
-      extent={{6,3},{6,3}}));
-  connect(bouAir.T_in, weaBus1.Te) annotation (Line(points={{382,174},{404,174},
-          {404,80.05},{380.05,80.05}}, color={0,0,127}));
   connect(fanSup.port_a, bouAir.ports[1]) annotation (Line(points={{340,140},{
           360,140},{360,172.667}},
                            color={0,127,255}));
@@ -241,6 +234,8 @@ equation
           {150,180}}, color={0,127,255}));
   connect(Diner.port_a, bouAir.ports[3]) annotation (Line(points={{-34,-38},{30,
           -38},{30,202},{360,202},{360,167.333}},     color={0,127,255}));
+  connect(Te.y, bouAir.T_in) annotation (Line(points={{395,140},{400,140},{400,
+          174},{382,174}}, color={0,0,127}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -200},{400,240}},
         initialScale=0.1), graphics={


### PR DESCRIPTION
…ildings library and make icon of weaBus very small such that the user does not use it.

this solves #830 .

Notice that still quite model use the bus `weaBus`:
![image](https://user-images.githubusercontent.com/2987659/41719332-0c11bf68-7560-11e8-91d5-ee2ff7eda451.png)

and that they often cannot be replaced by `weaDatBus`.

However, most users should not encounter a situation where he needs `weaBus` rather than `weaDatBus`.

@Mathadon what are your thoughts?
