### PR TITLE
Issue boptest364 input values

### DIFF
--- a/IDEAS/Examples/IBPSA/SingleZoneResidentialHydronic.mo
+++ b/IDEAS/Examples/IBPSA/SingleZoneResidentialHydronic.mo
@@ -144,29 +144,12 @@ model SingleZoneResidentialHydronic
         extent={{10,10},{-10,-10}},
         rotation=180,
         origin={-110,-80})));
-  Utilities.IO.SignalExchange.Read reaTSetCoo(description=
-        "Zone operative temperature setpoint for cooling",
-                                                     y(unit="K"))
-    "Read zone cooling setpoint"
-    annotation (Placement(transformation(extent={{-90,-60},{-70,-40}})));
-  Utilities.IO.SignalExchange.Read reaTSetHea(description=
-        "Zone operative temperature setpoint for heating",
-                                                     y(unit="K"))
-    "Read zone cooling heating"
-    annotation (Placement(transformation(extent={{-90,-90},{-70,-70}})));
   Modelica.Blocks.Sources.RealExpression TSetCoo(y=if yOcc.y > 0 then
         TSetCooOcc else TSetCooUno) "Cooling temperature setpoint with setback"
     annotation (Placement(transformation(extent={{-180,-60},{-160,-40}})));
   Modelica.Blocks.Sources.RealExpression TSetHea(y=if yOcc.y > 0 then
         TSetHeaOcc else TSetHeaUno) "Heating temperature setpoint with setback"
     annotation (Placement(transformation(extent={{-180,-90},{-160,-70}})));
-  Utilities.IO.SignalExchange.Read reaTSetSup(description=
-        "Supply temperature setpoint of heater", y(unit="K"))
-    "Read supply temperature setpoint of heater"
-    annotation (Placement(transformation(extent={{0,70},{20,90}})));
-  Utilities.IO.SignalExchange.Read reaPum(description="Control signal for pump",
-      y(unit="1")) "Read control signal for pump"
-    annotation (Placement(transformation(extent={{30,-80},{50,-60}})));
   Modelica.Blocks.Continuous.LimPID conPI(
     controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=10,
@@ -216,24 +199,8 @@ equation
           {-50,10},{-50,0},{58,0}}, color={0,0,127}));
   connect(QGas.y,reaQHea. u)
     annotation (Line(points={{51,60},{58,60}}, color={0,0,127}));
-  connect(oveTSetCoo.y, reaTSetCoo.u)
-    annotation (Line(points={{-99,-50},{-92,-50}}, color={0,0,127}));
-  connect(oveTSetHea.y, reaTSetHea.u)
-    annotation (Line(points={{-99,-80},{-92,-80}}, color={0,0,127}));
-  connect(reaTSetCoo.y, con.uHigh) annotation (Line(points={{-69,-50},{-42,-50},
-          {-42,-74},{-34,-74}}, color={0,0,127}));
-  connect(reaTSetHea.y, con.uLow) annotation (Line(points={{-69,-80},{-42,-80},
-          {-42,-78},{-34,-78}}, color={0,0,127}));
   connect(TSetCoo.y, oveTSetCoo.u)
     annotation (Line(points={{-159,-50},{-122,-50}}, color={0,0,127}));
-  connect(oveTSetSup.y, reaTSetSup.u)
-    annotation (Line(points={{-7,80},{-2,80}}, color={0,0,127}));
-  connect(reaTSetSup.y, hea.TSet) annotation (Line(points={{21,80},{28,80},{28,
-          38},{22,38}}, color={0,0,127}));
-  connect(ovePum.y, reaPum.u)
-    annotation (Line(points={{21,-70},{28,-70}}, color={0,0,127}));
-  connect(realToInteger.u, reaPum.y)
-    annotation (Line(points={{58,-70},{51,-70}}, color={0,0,127}));
   connect(conPI.y, oveTSetSup.u)
     annotation (Line(points={{-59,80},{-30,80}}, color={0,0,127}));
   connect(offSet.y, add.u1) annotation (Line(points={{-159,-10},{-156,-10},{-156,
@@ -249,8 +216,16 @@ equation
           -86},{-152,-86}}, color={0,0,127}));
   connect(add.y, oveTSetHea.u)
     annotation (Line(points={{-129,-80},{-122,-80}}, color={0,0,127}));
-  connect(reaTSetHea.y, conPI.u_s) annotation (Line(points={{-69,-80},{-60,-80},
-          {-60,-20},{-100,-20},{-100,80},{-82,80}}, color={0,0,127}));
+  connect(oveTSetSup.y, hea.TSet) annotation (Line(points={{-7,80},{26,80},{26,38},
+          {22,38}}, color={0,0,127}));
+  connect(ovePum.y, realToInteger.u)
+    annotation (Line(points={{21,-70},{58,-70}}, color={0,0,127}));
+  connect(oveTSetCoo.y, con.uHigh) annotation (Line(points={{-99,-50},{-54,-50},
+          {-54,-74},{-34,-74}}, color={0,0,127}));
+  connect(oveTSetHea.y, con.uLow) annotation (Line(points={{-99,-80},{-40,-80},{
+          -40,-78},{-34,-78}}, color={0,0,127}));
+  connect(oveTSetHea.y, conPI.u_s) annotation (Line(points={{-99,-80},{-94,-80},
+          {-94,80},{-82,80}}, color={0,0,127}));
   annotation (
     experiment(
       StopTime=31500000,
@@ -382,19 +357,7 @@ depicted as C2 in Figure 1.
 <p>The model outputs are: </p>
 <ul>
 <li>
-<code>reaTSetHea_y</code> [K] [min=None, max=None]: Zone operative temperature setpoint for heating
-</li>
-<li>
-<code>reaTSetCoo_y</code> [K] [min=None, max=None]: Zone operative temperature setpoint for cooling
-</li>
-<li>
-<code>reaTSetSup_y</code> [K] [min=None, max=None]: Supply temperature setpoint of heater
-</li>
-<li>
 <code>reaQHea_y</code> [W] [min=None, max=None]: Heating thermal power
-</li>
-<li>
-<code>reaPum_y</code> [1] [min=None, max=None]: Control signal for pump
 </li>
 <li>
 <code>reaPPum_y</code> [W] [min=None, max=None]: Pump electrical power
@@ -613,6 +576,12 @@ https://www.eia.gov/environment/emissions/co2_vol_mass.php</a>
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+December 2, 2021, by David Blum:<br/>
+Remove read blocks for control signals.
+This is for
+<a href=\"https://github.com/ibpsa/project1-boptest/issues/364\">BOPTEST issue #364</a>. 
+</li>
 <li>
 June 23, 2021, by David Blum:<br/>
 Add schematics to documentation and move heating set point offset to 

--- a/IDEAS/Examples/IBPSA/SingleZoneResidentialHydronicHeatPump.mo
+++ b/IDEAS/Examples/IBPSA/SingleZoneResidentialHydronicHeatPump.mo
@@ -98,13 +98,6 @@ model SingleZoneResidentialHydronicHeatPump
   Modelica.Blocks.Sources.RealExpression TSetHea(y=if yOcc.y > 0 then
         TSetHeaOcc else TSetHeaUno) "Heating temperature setpoint with setback"
     annotation (Placement(transformation(extent={{-200,-40},{-180,-20}})));
-  Utilities.IO.SignalExchange.Read reaHeaPumY(description="Block for reading the heat pump modulating signal",
-      y(unit="1")) "Read heat pump modulating signal"
-    annotation (Placement(transformation(extent={{180,140},{200,160}})));
-  Utilities.IO.SignalExchange.Read reaPum(description=
-        "Control signal for emission cirquit pump", y(unit="1"))
-    "Read control signal for emission circuit pump"
-    annotation (Placement(transformation(extent={{22,100},{42,120}})));
   Modelica.Blocks.Continuous.LimPID conPI(
     controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=0.6,
@@ -235,9 +228,6 @@ model SingleZoneResidentialHydronicHeatPump
         extent={{10,10},{-10,-10}},
         rotation=180,
         origin={202,110})));
-  Utilities.IO.SignalExchange.Read reaFan(description="Control signal for fan",
-      y(unit="1")) "Read control signal for fan"
-    annotation (Placement(transformation(extent={{222,100},{242,120}})));
   Modelica.Blocks.Sources.RealExpression yFan(y=if heaPum.com.isOn then 1 else 0)
     "Control input signal to fan"
     annotation (Placement(transformation(extent={{160,100},{180,120}})));
@@ -279,18 +269,10 @@ model SingleZoneResidentialHydronicHeatPump
         extent={{10,10},{-10,-10}},
         rotation=180,
         origin={30,150})));
-  Utilities.IO.SignalExchange.Read reaTSet(description=
-        "Zone operative temperature setpoint", y(unit="K"))
-    "Read zone temperature setpoint"
-    annotation (Placement(transformation(extent={{60,140},{80,160}})));
 equation
   connect(case900Template.ppm, reaCO2RooAir.u) annotation (Line(points={{-59,10},
           {-54,10},{-54,-50},{-58,-50}},
                                     color={0,0,127}));
-  connect(ovePum.y, reaPum.u)
-    annotation (Line(points={{13,110},{20,110}}, color={0,0,127}));
-  connect(realToInteger.u, reaPum.y)
-    annotation (Line(points={{50,110},{43,110}}, color={0,0,127}));
   connect(yOcc.y, case900Template.yOcc) annotation (Line(points={{-59,40},{-52,
           40},{-52,14},{-58,14}},
                               color={0,0,127}));
@@ -310,9 +292,6 @@ equation
     annotation (Line(points={{-20,10},{-20,-20},{60,-20}},color={0,127,255}));
   connect(pum.P, reaPPumEmi.u)
     annotation (Line(points={{19,49},{0,49},{0,80},{18,80}}, color={0,0,127}));
-  connect(reaHeaPumY.y, heaPum.y) annotation (Line(points={{201,150},{292,150},
-          {292,-24},{127,-24},{127,-2}},
-                                    color={0,0,127}));
   connect(yPum.y, ovePum.u)
     annotation (Line(points={{-19,110},{-10,110}}, color={0,0,127}));
   connect(realToInteger.y, pum.stage) annotation (Line(points={{73,110},{80,110},
@@ -334,10 +313,6 @@ equation
     annotation (Line(points={{70,-31},{70,-50},{98,-50}}, color={0,0,127}));
   connect(heaPumCOP.y, reaCOP.u)
     annotation (Line(points={{181,-50},{198,-50}}, color={0,0,127}));
-  connect(oveFan.y, reaFan.u)
-    annotation (Line(points={{213,110},{220,110}}, color={0,0,127}));
-  connect(realToInteger2.u, reaFan.y)
-    annotation (Line(points={{250,110},{243,110}}, color={0,0,127}));
   connect(yFan.y, oveFan.u)
     annotation (Line(points={{181,110},{190,110}}, color={0,0,127}));
   connect(fan.port_a, outAir.ports[1])
@@ -350,8 +325,6 @@ equation
           {-170,136},{-162,136}}, color={0,0,127}));
   connect(offSetUno.y, addUno.u1) annotation (Line(points={{-179,70},{-172,70},
           {-172,56},{-162,56}}, color={0,0,127}));
-  connect(oveHeaPumY.y, reaHeaPumY.u)
-    annotation (Line(points={{161,150},{178,150}}, color={0,0,127}));
   connect(greater.y, switch1.u2) annotation (Line(points={{-59,80},{-52,80},{
           -52,150},{-22,150}}, color={255,0,255}));
   connect(case900Template.TSensor, conPI.u_m) annotation (Line(points={{-59,12},
@@ -378,10 +351,6 @@ equation
       thickness=0.5));
   connect(switch1.y, oveTSet.u)
     annotation (Line(points={{1,150},{18,150}}, color={0,0,127}));
-  connect(oveTSet.y, reaTSet.u)
-    annotation (Line(points={{41,150},{58,150}}, color={0,0,127}));
-  connect(reaTSet.y, conPI.u_s)
-    annotation (Line(points={{81,150},{98,150}}, color={0,0,127}));
   connect(TSetCoo.y, reaTSetCoo.u)
     annotation (Line(points={{-179,10},{-162,10}}, color={0,0,127}));
   connect(TSetHea.y, reaTSetHea.u) annotation (Line(points={{-179,-30},{-172,
@@ -390,6 +359,14 @@ equation
           {-170,-60},{-220,-60},{-220,44},{-162,44}}, color={0,0,127}));
   connect(TSetHea.y, addOcc.u2) annotation (Line(points={{-179,-30},{-170,-30},
           {-170,-60},{-220,-60},{-220,124},{-162,124}}, color={0,0,127}));
+  connect(oveTSet.y, conPI.u_s)
+    annotation (Line(points={{41,150},{98,150}}, color={0,0,127}));
+  connect(oveHeaPumY.y, heaPum.y) annotation (Line(points={{161,150},{290,150},{
+          290,-30},{127,-30},{127,-2}}, color={0,0,127}));
+  connect(oveFan.y, realToInteger2.u)
+    annotation (Line(points={{213,110},{250,110}}, color={0,0,127}));
+  connect(ovePum.y, realToInteger.u)
+    annotation (Line(points={{13,110},{50,110}}, color={0,0,127}));
   annotation (
     experiment(
       StopTime=1728000,
@@ -680,12 +657,6 @@ is depicted as controller C2 in Figure 1.
 <code>reaCOP_y</code> [1] [min=None, max=None]: Heat pump COP
 </li>
 <li>
-<code>reaFan_y</code> [1] [min=None, max=None]: Control signal for fan
-</li>
-<li>
-<code>reaHeaPumY_y</code> [1] [min=None, max=None]: Block for reading the heat pump modulating signal
-</li>
-<li>
 <code>reaPFan_y</code> [W] [min=None, max=None]: Electrical power of the heat pump evaporator fan
 </li>
 <li>
@@ -693,9 +664,6 @@ is depicted as controller C2 in Figure 1.
 </li>
 <li>
 <code>reaPPumEmi_y</code> [W] [min=None, max=None]: Emission circuit pump electrical power
-</li>
-<li>
-<code>reaPum_y</code> [1] [min=None, max=None]: Control signal for emission cirquit pump
 </li>
 <li>
 <code>reaQFloHea_y</code> [W] [min=None, max=None]: Floor heating thermal power released to the zone
@@ -714,9 +682,6 @@ is depicted as controller C2 in Figure 1.
 </li>
 <li>
 <code>reaTSetHea_y</code> [K] [min=None, max=None]: Zone operative temperature setpoint for heating
-</li>
-<li>
-<code>reaTSet_y</code> [K] [min=None, max=None]: Zone operative temperature setpoint
 </li>
 <li>
 <code>reaTSup_y</code> [K] [min=None, max=None]: Supply water temperature to radiant floor
@@ -907,6 +872,12 @@ https://www.carbonfootprint.com/docs/2019_06_emissions_factors_sources_for_2019_
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+December 2, 2021, by David Blum:<br/>
+Remove read blocks for control signals.
+This is for
+<a href=\"https://github.com/ibpsa/project1-boptest/issues/364\">BOPTEST issue #364</a>. 
+</li>
 <li>
 June 23, 2021, by David Blum:<br/>
 Add schematics to documentation.


### PR DESCRIPTION
This is for BOPTEST issue https://github.com/ibpsa/project1-boptest/issues/364.  In particular, it updates the ``IDEAS.Examples.IBPSA.SingleZoneResidentialHydronic`` and ``IDEAS.Examples.IBPSA.SingleZoneResidentialHydronicHeatPump`` to remove the instances of the signal exchange read blocks (of class ``IDEAS.Utilities.IO.SignalExchange.Read``) that are used to report the "current value" of a control signal utilized within the model (those implemented directly after an instance of ``IDEAS.Utilities.IO.SignalExchange.Overwrite``).  With https://github.com/ibpsa/project1-boptest/issues/364, and corresponding PR https://github.com/ibpsa/project1-boptest/pull/377, this is to be handled within BOPTEST for all instances of overwrite blocks (``IDEAS.Utilities.IO.SignalExchange.Overwrite``).