### PR TITLE
Expandable bus connectors for #1317

### DIFF
--- a/IDEAS/Buildings/Components/Interfaces/SolBus.mo
+++ b/IDEAS/Buildings/Components/Interfaces/SolBus.mo
@@ -1,5 +1,5 @@
 within IDEAS.Buildings.Components.Interfaces;
-connector SolBus
+expandable connector SolBus
   "Bus containing solar radiation for various incidence angles as well as external convection coefficients"
   parameter Boolean outputAngles = true "Set to false when linearising in Dymola only";
   IDEAS.Buildings.Components.Interfaces.RealConnector HDirTil(unit="W/(m2)",start=100) annotation ();

--- a/IDEAS/Buildings/Components/Interfaces/WeaBus.mo
+++ b/IDEAS/Buildings/Components/Interfaces/WeaBus.mo
@@ -1,5 +1,5 @@
 within IDEAS.Buildings.Components.Interfaces;
-connector WeaBus "Data bus that stores weather data"
+expandable connector WeaBus "Data bus that stores weather data"
   parameter Integer numSolBus;
   parameter Boolean outputAngles = true "Set to false when linearising in Dymola only";
 

--- a/IDEAS/Buildings/Components/Interfaces/WindowBus.mo
+++ b/IDEAS/Buildings/Components/Interfaces/WindowBus.mo
@@ -1,5 +1,5 @@
 within IDEAS.Buildings.Components.Interfaces;
-connector WindowBus
+expandable connector WindowBus
   "Bus containing inputs/outputs for linear window model"
   parameter Integer nLay = 3 "Number of window layers";
 

--- a/IDEAS/Buildings/Components/Interfaces/ZoneBus.mo
+++ b/IDEAS/Buildings/Components/Interfaces/ZoneBus.mo
@@ -1,5 +1,5 @@
 within IDEAS.Buildings.Components.Interfaces;
-connector ZoneBus
+expandable connector ZoneBus
   replaceable package Medium =
     Modelica.Media.Interfaces.PartialMedium "Medium in the component";
   parameter Integer numIncAndAziInBus


### PR DESCRIPTION
Making the bus connectors expandable seems to avoid the errors mentioned in #1317. Within Dymola these errors are only raised when performing a pedantic check, which means that the old implementation was not totally conform the Modelica specification.

Before merging this script, we must fix the CI runner first (#1316) to make sure that we don't break our models by this change.