### PR TITLE
Project itz fixes v2

### DIFF
--- a/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
+++ b/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
@@ -96,8 +96,8 @@ model CrackOrOperableDoor
     Placement(visible = true, transformation(origin = {0, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
  IDEAS.Airflow.Multizone.DoorDiscretizedOperable doo(
    redeclare package Medium = Medium,
-   final hA = 0,
-   final hB = 0,
+   final hA = (h_a1+h_b2)/2,
+   final hB = (h_a2+h_b1)/2,
    final forceErrorControlOnFlow=false,
    dp_turbulent=dp_turbulent,
    nCom=nCom,
@@ -145,14 +145,6 @@ equation
     Line(points = {{-60, 60}, {-100, 60}}, color = {0, 127, 255}));
  connect(y, doo.y) annotation (
     Line(points={{-110,0},{-11,0}},      color = {0, 0, 127}));
- connect(doo.port_a1, col_a1.port_a) annotation (
-    Line(points = {{-10, 6}, {-20, 6}, {-20, 84}, {-60, 84}, {-60, 80}}, color = {0, 127, 255}));
- connect(doo.port_b1, col_b1.port_a) annotation (
-    Line(points = {{10, 6}, {20, 6}, {20, 84}, {60, 84}, {60, 80}}, color = {0, 127, 255}));
- connect(doo.port_b2, col_b2.port_a) annotation (
-    Line(points = {{-10, -6}, {-20, -6}, {-20, -36}, {-60, -36}, {-60, -40}}, color = {0, 127, 255}));
- connect(doo.port_a2, col_a2.port_a) annotation (
-    Line(points = {{10, -6}, {20, -6}, {20, -36}, {60, -36}, {60, -40}}, color = {0, 127, 255}));
  connect(bou.ports[1], port_a2) annotation (
     Line(points={{-1,-80},{100,-80},{100,-60}},       color = {0, 127, 255}));
  if  interZonalAirFlowType <> IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts then
@@ -169,6 +161,14 @@ equation
     Line(points={{-47.4,-14},{-32,-14},{-32,0},{-11,0}},        color = {0, 0, 127}));
  connect(bou.ports[2], port_b2) annotation (
     Line(points={{1,-80},{-100,-80},{-100,-60}},        color = {0, 127, 255}));
+ connect(doo.port_a1, port_a1) annotation(
+    Line(points = {{-10, 6}, {-30, 6}, {-30, 60}, {-100, 60}}, color = {0, 127, 255}));
+ connect(doo.port_b1, port_b1) annotation(
+    Line(points = {{10, 6}, {30, 6}, {30, 60}, {100, 60}}, color = {0, 127, 255}));
+ connect(doo.port_b2, port_b2) annotation(
+    Line(points = {{-10, -6}, {-20, -6}, {-20, -34}, {-100, -34}, {-100, -60}}, color = {0, 127, 255}));
+ connect(doo.port_a2, port_a2) annotation(
+    Line(points = {{10, -6}, {20, -6}, {20, -34}, {100, -34}, {100, -60}}, color = {0, 127, 255}));
 
 annotation(Documentation(info="<html>
 <p>

--- a/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
+++ b/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
@@ -78,13 +78,13 @@ model CrackOrOperableDoor
   m = if openDoorOnePort and interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.OnePort then mOpe else mClo,
   useDefaultProperties = false) if not useDoor or (useDoor and interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.OnePort) "Pressure drop equation" annotation (
     Placement(visible = true, transformation(origin = {0, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
- IDEAS.Airflow.Multizone.ReversibleDensityColumn col_b1(redeclare package Medium = Medium, h=h_b1) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts "Column for port b1" annotation (
+ IDEAS.Airflow.Multizone.ReversibleDensityColumn col_b1(redeclare package Medium = Medium, h=h_b1) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts and not useDoor "Column for port b1" annotation (
     Placement(visible = true, transformation(origin = {0, 70}, extent = {{50, -10}, {70, 10}}, rotation = 0)));
- IDEAS.Airflow.Multizone.ReversibleDensityColumn col_a1(redeclare package Medium = Medium, h=h_a1) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts "Column for port a1" annotation (
+ IDEAS.Airflow.Multizone.ReversibleDensityColumn col_a1(redeclare package Medium = Medium, h=h_a1) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts and not useDoor "Column for port a1" annotation (
     Placement(visible = true, transformation(origin = {0, 70}, extent = {{-70, -10}, {-50, 10}}, rotation = 0)));
- IDEAS.Airflow.Multizone.ReversibleDensityColumn col_b2(redeclare package Medium = Medium, h=h_b2) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts "Column for port b2" annotation (
+ IDEAS.Airflow.Multizone.ReversibleDensityColumn col_b2(redeclare package Medium = Medium, h=h_b2) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts  and not useDoor"Column for port b2" annotation (
     Placement(visible = true, transformation(origin = {0, -50}, extent = {{-70, -10}, {-50, 10}}, rotation = 0)));
- IDEAS.Airflow.Multizone.ReversibleDensityColumn col_a2(redeclare package Medium = Medium, h=h_a2) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts "Column for port a2" annotation (
+ IDEAS.Airflow.Multizone.ReversibleDensityColumn col_a2(redeclare package Medium = Medium, h=h_a2) if interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts and not useDoor "Column for port a2" annotation (
     Placement(visible = true, transformation(origin = {0, -50}, extent = {{50, -10}, {70, 10}}, rotation = 0)));
  IDEAS.Airflow.Multizone.Point_m_flow point_m_flow2(
    redeclare package Medium = Medium,

--- a/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
+++ b/IDEAS/Airflow/Multizone/CrackOrOperableDoor.mo
@@ -56,7 +56,7 @@ model CrackOrOperableDoor
   parameter Real mClo= 0.65 "Flow exponent for crack of closed door"
     annotation (Dialog(group="Closed door"));
 
-  parameter Integer nCom=10 "Number of compartments for the discretization";
+  parameter Integer nCom=if abs(hOpe)<Modelica.Constants.small then 2 else 4 "Number of compartments for the discretization";
 
   parameter Boolean useDoor = false  "=true, to use operable door instead of a crack";
   parameter Boolean use_y = true "=true, to use control input";

--- a/IDEAS/BoundaryConditions/Interfaces/PartialSimInfoManager.mo
+++ b/IDEAS/BoundaryConditions/Interfaces/PartialSimInfoManager.mo
@@ -115,8 +115,6 @@ partial model PartialSimInfoManager
     annotation (Dialog(group="Wind"));
   parameter Real Cs_coeff = (A0*A0)*((1/Hwind)^(2*a)) "Multiplication factor for Habs"
     annotation(Dialog(group="Wind"));
-  parameter Modelica.Units.SI.Length Hpres=1 "Height above ground of meteorological ambient pressure measurement"
-    annotation(Dialog(group="Wind"));
   constant Modelica.Units.SI.Density rho_default = 1.2 "Default air density"
     annotation(Dialog(group="Wind"));
 

--- a/IDEAS/Buildings/Components/Interfaces/PartialSurface.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialSurface.mo
@@ -55,8 +55,8 @@ partial model PartialSurface "Partial model for building envelope component"
 
   final parameter Modelica.Units.SI.Length hzone_a( fixed=false);//connected with propsbus in inital equation
   final parameter Modelica.Units.SI.Length hAbs_floor_a( fixed=false);
-  parameter Modelica.Units.SI.Length hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc,Modelica.IDEAS.Tilt.Floor) or IDEAS.Utilities.Math.Functions.isAngle(inc,IDEAS.Tilt.Ceiling) then 0 else hzone_a "Vertical surface height, height of the surface projected to the vertical, 0 for floors and ceilings" annotation(Evaluate=true);
-  parameter Modelica.Units.SI.Length hRelSurfBot_a= if IDEAS.Utilities.Math.Functions.isAngle(inc,IDEAS.Tilt.Ceiling) then hzone_a else 0  "Height between the lowest point of the surface (bottom) and the floor level of the zone connected at propsBus_a"annotation(Evaluate=true);
+  parameter Modelica.Units.SI.Length hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc,IDEAS.Types.Tilt.Floor) or IDEAS.Utilities.Math.Functions.isAngle(inc,IDEAS.Types.Tilt.Ceiling) then 0 else hzone_a "Vertical surface height, height of the surface projected to the vertical, 0 for floors and ceilings" annotation(Evaluate=true);
+  parameter Modelica.Units.SI.Length hRelSurfBot_a= if IDEAS.Utilities.Math.Functions.isAngle(inc,IDEAS.Types.Tilt.Ceiling) then hzone_a else 0  "Height between the lowest point of the surface (bottom) and the floor level of the zone connected at propsBus_a"annotation(Evaluate=true);
   final parameter Modelica.Units.SI.Length Habs_surf=hAbs_floor_a+hRelSurfBot_a+(hVertical/2)  "Absolute height of the middle of the surface, can be used to check the heights after initialisation";
 
   IDEAS.Buildings.Components.Interfaces.ZoneBus propsBus_a(
@@ -101,8 +101,8 @@ partial model PartialSurface "Partial model for building envelope component"
     A_q50 = A,
     q50=q50_internal,
     redeclare package Medium = Medium,
-    h_a1=Habs+ 0.25*hVertical,
-    h_b2=Habs - 0.25*hVertical,
+    h_a1=0.25*hVertical,
+    h_b2=- 0.25*hVertical,
     h_a2 = 0.75*hVertical + hRelSurfBot_a,
     h_b1 = 0.25*hVertical + hRelSurfBot_a,
     interZonalAirFlowType = sim.interZonalAirFlowType) if add_door and sim.interZonalAirFlowType <> IDEAS.BoundaryConditions.Types.InterZonalAirFlow.None annotation(

--- a/IDEAS/Buildings/Components/Interfaces/PartialSurface.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialSurface.mo
@@ -101,8 +101,10 @@ partial model PartialSurface "Partial model for building envelope component"
     A_q50 = A,
     q50=q50_internal,
     redeclare package Medium = Medium,
-    h_a2 = -0.5*hzone_a + 0.75*hVertical + hRelSurfBot_a,
-    h_b1 = -0.5*hzone_a + 0.25*hVertical + hRelSurfBot_a,
+    h_a1=Habs+ 0.25*hVertical,
+    h_b2=Habs - 0.25*hVertical,
+    h_a2 = 0.75*hVertical + hRelSurfBot_a,
+    h_b1 = 0.25*hVertical + hRelSurfBot_a,
     interZonalAirFlowType = sim.interZonalAirFlowType) if add_door and sim.interZonalAirFlowType <> IDEAS.BoundaryConditions.Types.InterZonalAirFlow.None annotation(
     Placement(visible = true, transformation(origin = {30, -52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Sources.RealExpression AExp(y = A) "Area expression" annotation(

--- a/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
@@ -259,7 +259,7 @@ model Setq50 "q50 computation for zones"
     "custom assigned v50 value, else zero";
 
   parameter Modelica.Units.SI.Length hZone "Zone height: distance between floor and ceiling";
-  parameter Modelica.Units.SI.Length hFloor = 0  "Absolute height of zone floor";
+  parameter Modelica.Units.SI.Length hFloor = 0  "Absolute height of zone floor. Relative to the height at which the atmospheric pressure is defined.";
 
   Modelica.Blocks.Interfaces.RealInput v50_surf[nSurf]
    annotation (Placement(transformation(extent={{-126,28},{-86,68}})));

--- a/IDEAS/Buildings/Components/Interfaces/ZoneBus.mo
+++ b/IDEAS/Buildings/Components/Interfaces/ZoneBus.mo
@@ -1,5 +1,5 @@
 within IDEAS.Buildings.Components.Interfaces;
-expandable connector ZoneBus
+connector ZoneBus
   replaceable package Medium =
     Modelica.Media.Interfaces.PartialMedium "Medium in the component";
   parameter Integer numIncAndAziInBus

--- a/IDEAS/Buildings/Components/InternalWall.mo
+++ b/IDEAS/Buildings/Components/InternalWall.mo
@@ -16,6 +16,7 @@ model InternalWall "interior opaque wall between two zones"
       use_y=use_y_doo,
       wOpe=w,
       hOpe=h,
+      CDOpe=CD,
       h_a1=-0.5*hzone_b + 0.25*hVertical + hRef_b,
       h_b2=-0.5*hzone_b + 0.75*hVertical + hRef_b));
   //using custom q50 since this model is not an external component

--- a/IDEAS/Buildings/Components/InternalWall.mo
+++ b/IDEAS/Buildings/Components/InternalWall.mo
@@ -126,8 +126,8 @@ initial equation
   hfloor_b = propsBus_b.hfloor;
 equation
   connect(constOne.y, crackOrOperableDoor.y);
-//assert(IDEAS.Utilities.Math.Functions.isAngle(inc,0) and hfloor_a>hfloor_b, getInstanceName()+ "is a ceiling, but the floor of the zone at probsbus_b lies above the floor of zone at probsbus_a, this is probably a mistake",level=AssertionLevel.warning);
-//assert(IDEAS.Utilities.Math.Functions.isAngle(inc,Modelica.Constants.pi) and hfloor_a<hfloor_b, getInstanceName()+ "is a floor, but the floor of the zone at probsbus_b lies above the floor of zone at probsbus_a, this is probably a mistake",level=AssertionLevel.warning);
+//assert(IDEAS.Utilities.Math.Functions.isAngle(inc,0) and hAbs_floor_a>hfloor_b, getInstanceName()+ "is a ceiling, but the floor of the zone at probsbus_b lies above the floor of zone at probsbus_a, this is probably a mistake",level=AssertionLevel.warning);
+//assert(IDEAS.Utilities.Math.Functions.isAngle(inc,Modelica.Constants.pi) and hAbs_floor_a<hfloor_b, getInstanceName()+ "is a floor, but the floor of the zone at probsbus_b lies above the floor of zone at probsbus_a, this is probably a mistake",level=AssertionLevel.warning);
   assert(hasCavity == false or IDEAS.Utilities.Math.Functions.isAngle(incInt, IDEAS.Types.Tilt.Wall), "In " + getInstanceName() + ": Cavities are only supported for vertical walls, but inc=" + String(incInt) + ". The model is not accurate.", level = AssertionLevel.warning);
   connect(layMul.port_b, propsBus_b.surfRad) annotation(
     Line(points = {{-10, 0}, {-18, 0}, {-18, 20.1}, {-100.1, 20.1}}, color = {191, 0, 0}, smooth = Smooth.None));

--- a/IDEAS/Buildings/Components/OuterWall.mo
+++ b/IDEAS/Buildings/Components/OuterWall.mo
@@ -6,8 +6,8 @@ model OuterWall "Opaque building envelope construction"
      dT_nominal_a=-3,
      QTra_design(fixed=false),
     crackOrOperableDoor(
-      h_a1=(Habs - sim.Hpres) + 0.25*hVertical,
-      h_b2=(Habs - sim.Hpres) - 0.25*hVertical));
+      h_a1=Habs + 0.25*hVertical,
+      h_b2=Habs - 0.25*hVertical));
 
   parameter Boolean linExtCon=sim.linExtCon
     "= true, if exterior convective heat transfer should be linearised (uses average wind speed)"

--- a/IDEAS/Buildings/Components/OuterWall.mo
+++ b/IDEAS/Buildings/Components/OuterWall.mo
@@ -70,7 +70,7 @@ model OuterWall "Opaque building envelope construction"
   parameter Real Cs=sim.Cs
                        "Wind speed modifier"
     annotation (Dialog(enable=use_custom_Cs,tab="Airflow", group="Wind Pressure"));
-  final parameter Real Habs=hfloor_a + hRef_a + (hVertical/2)
+  final parameter Real Habs=hAbs_floor_a + hRelSurfBot_a + (hVertical/2)
     "Absolute height of the center of the surface for correcting the wind speed, used in TwoPort implementation"
     annotation (Dialog(tab="Airflow", group="Wind"));
 

--- a/IDEAS/Buildings/Components/OuterWall.mo
+++ b/IDEAS/Buildings/Components/OuterWall.mo
@@ -4,10 +4,7 @@ model OuterWall "Opaque building envelope construction"
      setArea(A=A),
      final nWin=1,
      dT_nominal_a=-3,
-     QTra_design(fixed=false),
-    crackOrOperableDoor(
-      h_a1=Habs + 0.25*hVertical,
-      h_b2=Habs - 0.25*hVertical));
+     QTra_design(fixed=false));
 
   parameter Boolean linExtCon=sim.linExtCon
     "= true, if exterior convective heat transfer should be linearised (uses average wind speed)"

--- a/IDEAS/Buildings/Components/Validations/WindowEN673.mo
+++ b/IDEAS/Buildings/Components/Validations/WindowEN673.mo
@@ -92,6 +92,7 @@ model WindowEN673 "Verifies U value of a glazing record"
     inc=IDEAS.Types.Tilt.Wall,
     azi=IDEAS.Types.Azimuth.S,
     A=1,
+    frac=0,
     gainDir(k=0),
     gainDif(k=0),
     redeclare Data.Glazing.Ins2Ar2020 glazing,
@@ -146,6 +147,10 @@ equation
       Tolerance=1e-06,
       __Dymola_Algorithm="Lsodar"),        Documentation(revisions="<html>
 <ul>
+<li>
+November 6, 2023, by Filip Jorissen:<br/>
+Set frame fraction to zero in normal window.
+</li>
 <li>
 July 20, 2020, by Filip Jorissen:<br/>
 Updated glazing type.

--- a/IDEAS/Buildings/Components/Window.mo
+++ b/IDEAS/Buildings/Components/Window.mo
@@ -31,8 +31,6 @@ model Window "Multipane window"
     q50_zone(v50_surf=q50_internal*A),
     crackOrOperableDoor(
           openDoorOnePort=false,
-          h_a1=Habs+ 0.25*hVertical,
-          h_b2=Habs - 0.25*hVertical,
           useDoor = use_operable_window));
   parameter Boolean linExtCon=sim.linExtCon
     "= true, if exterior convective heat transfer should be linearised (uses average wind speed)"

--- a/IDEAS/Buildings/Components/Window.mo
+++ b/IDEAS/Buildings/Components/Window.mo
@@ -26,8 +26,8 @@ model Window "Multipane window"
       linIntCon=true,
       checkCoatings=glazing.checkLowPerformanceGlazing),
     setArea(A=A*nWin),
-    hRef_a=if IDEAS.Utilities.Math.Functions.isAngle(inc, 0) then hzone_a else (hzone_a - hVertical)/2,
-    hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc, Modelica.Constants.pi) or IDEAS.Utilities.Math.Functions.isAngle(inc, 0) then 0 else hWin,
+    hRelSurfBot_a=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Ceiling) then hzone_a else (hzone_a - hVertical)/2,
+    hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Floor) or IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Ceiling) then 0 else hWin,
     q50_zone(v50_surf=q50_internal*A),
     crackOrOperableDoor(
           openDoorOnePort=false,
@@ -110,7 +110,7 @@ model Window "Multipane window"
         annotation (Dialog(enable=use_custom_Cs,tab="Airflow", group="Wind Pressure"));
 
   final parameter Real Habs(fixed=false)
-    "Absolute height of boundary for correcting the wind speed"
+    "Absolute height at the middle of the window"
     annotation (Dialog(tab="Airflow", group="Wind"));
   parameter Boolean use_operable_window = false
     "= true, to enable window control input"
@@ -242,7 +242,7 @@ protected
 
 initial equation
   QTra_design = (U_value*A + fraType.briTyp.G) *(273.15 + 21 - Tdes.y);
-  Habs =hfloor_a + hRef_a + (hVertical/2);
+  Habs =hAbs_floor_a + hRelSurfBot_a + (hVertical/2);
 
   assert(not use_trickle_vent or sim.interZonalAirFlowType <> IDEAS.BoundaryConditions.Types.InterZonalAirFlow.None,
     "In " + getInstanceName() + ": Trickle vents can only be enabled when sim.interZonalAirFlowType is not None.");

--- a/IDEAS/Buildings/Components/Window.mo
+++ b/IDEAS/Buildings/Components/Window.mo
@@ -183,6 +183,8 @@ model Window "Multipane window"
   Modelica.Blocks.Sources.RealExpression y_window_trunc(y = max(0, min(1, y_window_internal)))
     "Truncated control signal" annotation (
     Placement(visible = true, transformation(origin = {-10, -90}, extent = {{-10, 10}, {10, -10}}, rotation = 90)));
+  Airflow.Multizone.ReversibleDensityColumn col_trickle(redeclare package Medium = Medium) if sim.interZonalAirFlowType == IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts "Column for port trickle vent" annotation(
+    Placement(transformation(origin = {112, -40}, extent = {{50, -10}, {70, 10}}, rotation = 180)));
 protected
   Modelica.Blocks.Interfaces.RealInput y_window_internal;
   final parameter Real U_value=glazing.U_value*(1-frac)+fraType.U_value*frac
@@ -313,8 +315,6 @@ equation
     Line(points = {{-10, 70}, {-10, 100}}, color = {191, 0, 0}));
   connect(heaCapGlaExt.port, layMul.port_b) annotation (
     Line(points = {{-10, -12}, {-10, 0}}, color = {191, 0, 0}));
-  connect(trickleVent.port_b, propsBusInt.port_1) annotation (
-    Line(points = {{40, -80}, {50, -80}, {50, 19.91}, {56.09, 19.91}}, color = {0, 127, 255}));
   connect(radSolData.Te, shaType.Te) annotation (
     Line(points={{-79.4,-64},{-68.5,-64},{-68.5,-29.9067}}, color = {0, 0, 127}));
   connect(shaType.port_frame, layFra.port_b) annotation (
@@ -346,6 +346,14 @@ equation
     Line(points={{-10,-79},{-10,-58}},      color = {0, 0, 127}));
  connect(y_window_trunc.y, crackOrOperableDoor.y) annotation (
     Line(points={{-10,-79},{-10,-68},{19,-68},{19,-52}},          color = {0, 0, 127}));
+ if sim.interZonalAirFlowType <> IDEAS.BoundaryConditions.Types.InterZonalAirFlow.TwoPorts then
+   connect(trickleVent.port_b, propsBusInt.port_1) annotation(
+    Line(points = {{40, -80}, {50, -80}, {50, 19.91}, {56.09, 19.91}}, color = {0, 127, 255}));
+ end if;
+ connect(trickleVent.port_b, col_trickle.port_a) annotation(
+    Line(points = {{40, -80}, {52, -80}, {52, -50}}, color = {0, 127, 255}));
+ connect(col_trickle.port_b, propsBusInt.port_1) annotation(
+    Line(points = {{52, -30}, {56, -30}, {56, 20}}, color = {0, 127, 255}));
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-60,-100},{60,100}}),
         graphics={Rectangle(fillColor = {255, 255, 255}, pattern = LinePattern.None,

--- a/IDEAS/Buildings/Components/Window.mo
+++ b/IDEAS/Buildings/Components/Window.mo
@@ -31,8 +31,8 @@ model Window "Multipane window"
     q50_zone(v50_surf=q50_internal*A),
     crackOrOperableDoor(
           openDoorOnePort=false,
-          h_a1=(Habs - sim.Hpres) + 0.25*hVertical,
-          h_b2=(Habs - sim.Hpres) - 0.25*hVertical,
+          h_a1=Habs+ 0.25*hVertical,
+          h_b2=Habs - 0.25*hVertical,
           useDoor = use_operable_window));
   parameter Boolean linExtCon=sim.linExtCon
     "= true, if exterior convective heat transfer should be linearised (uses average wind speed)"

--- a/IDEAS/Buildings/Components/Window.mo
+++ b/IDEAS/Buildings/Components/Window.mo
@@ -26,8 +26,8 @@ model Window "Multipane window"
       linIntCon=true,
       checkCoatings=glazing.checkLowPerformanceGlazing),
     setArea(A=A*nWin),
-    hRelSurfBot_a=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Ceiling) then hzone_a else (hzone_a - hVertical)/2,
-    hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Floor) or IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Tilt.Ceiling) then 0 else hWin,
+    hRelSurfBot_a=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Types.Tilt.Ceiling) then hzone_a else (hzone_a - hVertical)/2,
+    hVertical=if IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Types.Tilt.Floor) or IDEAS.Utilities.Math.Functions.isAngle(inc, IDEAS.Types.Tilt.Ceiling) then 0 else hWin,
     q50_zone(v50_surf=q50_internal*A),
     crackOrOperableDoor(
           openDoorOnePort=false,

--- a/IDEAS/Examples/PPD12/Structure.mo
+++ b/IDEAS/Examples/PPD12/Structure.mo
@@ -75,7 +75,7 @@ model Structure "Ppd 12 example model"
     annotation (Placement(transformation(extent={{70,68},{80,88}})));
   IDEAS.Buildings.Components.Window winBed3(
     hVertical=1.2*sin(winBed3.inc),
-    hRef_a=winBed3.hzone_a + 1,
+    hRelSurfMid_a=winBed3.hzone_a + 1,
     frac=0.1,
     azi=east,
     redeclare IDEAS.Examples.PPD12.Data.PvcInsulated fraType,
@@ -92,7 +92,7 @@ model Structure "Ppd 12 example model"
     A=wBedroom*lHalfBuilding*sqrt(2)/2,
     redeclare IDEAS.Examples.PPD12.Data.Roof constructionType,
     hVertical=lHalfBuilding*tan(Roof2.inc),
-    hRef_a=Roof2.hzone_a)
+    hRelSurfMid_a=Roof2.hzone_a)
     "Roof, east side"
     annotation (Placement(transformation(
         extent={{-5,-10},{5,10}},
@@ -359,7 +359,7 @@ model Structure "Ppd 12 example model"
     A=wBedroom*lHalfBuilding*sqrt(2),
     redeclare IDEAS.Examples.PPD12.Data.Roof constructionType,
     hVertical=lHalfBuilding*tan(Roof1.inc),
-    hRef_a=Roof1.hzone_a)
+    hRelSurfMid_a=Roof1.hzone_a)
     "Roof, west side"                     annotation (Placement(transformation(
         extent={{-5,-10},{5,10}},
         rotation=90,

--- a/IDEAS/Fluid/Sources/OutsideAir.mo
+++ b/IDEAS/Fluid/Sources/OutsideAir.mo
@@ -20,7 +20,7 @@ model OutsideAir
   Modelica.Units.SI.Density rho = IDEAS.Utilities.Psychrometrics.Functions.density_pTX(
         p=Medium.p_default,
         T=T_in_internal,
-        X_w=X_in_internal);
+        X_w=X_wEnv);
   
   Modelica.Units.SI.Angle alpha "Wind incidence angle (0: normal to wall)";
   Real CpAct(final unit="1") = windPressureProfile(u=alpha, table=table[:, :]) "Actual wind pressure coefficient";
@@ -120,7 +120,7 @@ end windPressureProfile;
   Modelica.Blocks.Interfaces.RealInput vWin(final unit="m/s") = sim.Va   "Wind speed from weather bus";
   Modelica.Blocks.Interfaces.RealInput winDir( final unit="rad",displayUnit="deg") = sim.Vdir "Wind direction from weather bus";
   Modelica.Blocks.Math.Add adder;
- Modelica.Blocks.Sources.RealExpression dpStack(k=Habs*Modelica.Constants.g*rho);
+ Modelica.Blocks.Sources.RealExpression dpStack(y=Habs*Modelica.Constants.g_n*rho);
 equation
 
   alpha = winDir-surOut;


### PR DESCRIPTION
@kldjonge I have made some revisions to your models:
 - revised some variable names so make more clear what they mean
 - I move part of the stack computation to the `outsideAir` component. This seemed more logical since you expect this component to give the correct pressure since it already has a variable `Habs`. 
 - This means that I have removed `Habs` (or it's equivalent) from the stack height computations for walls/windows. As far as I understand this is more correct than the current implementation since right now, assuming you have a zone at height 100m, we'd compute a stack 100m downwards with density `a` and then a stack 100m upwards with density `b`, which is now what happens in practice of course.
 - I have add a missing pressure column for the trickle vent (It was missing because I thought It was included in the `OutsideAir` already.)

Can you verify whether you agree with this logic and whether you agree with the implementation?

@jelgerjansen fyi