### PR TITLE
Update asserts for ZoneLwDistribution

### DIFF
--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
@@ -8,7 +8,8 @@ model LongwaveHeatTransfer
                   "Linearised interior heat radiation model"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   IDEAS.Buildings.Components.BaseClasses.RadiativeHeatTransfer.ZoneLwDistribution
-    zonLwDist(nSurf=2, linearise=false)
+    zonLwDist(nSurf=2,
+    ignAss=true,       linearise=false)
     "Model for longwave radiative heat exchange within a zone"
     annotation (Placement(transformation(extent={{10,-80},{-10,-60}})));
   Modelica.Blocks.Sources.Ramp ramp(

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
@@ -83,10 +83,10 @@ equation
           "Resources/Scripts/Dymola/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mos"
         "Simulate and plot"),
     Documentation(revisions="<html>
-    <ul>
+<ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Set parameter to ignore view factor assert.
+Set parameter <code>ignAss</code> to ignore view factor assert.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li>    
 <li>

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
@@ -32,7 +32,7 @@ model LongwaveHeatTransfer
   Modelica.Blocks.Sources.Constant A(k=10) "Heat exchange surface area"
     annotation (Placement(transformation(extent={{100,-40},{80,-20}})));
   IDEAS.Buildings.Components.BaseClasses.RadiativeHeatTransfer.ZoneLwDistribution
-    zonLwDistLin(nSurf=2)
+    zonLwDistLin(nSurf=2, ignAss=true)
     "Linearised model for longwave radiative heat exchange within a zone"
     annotation (Placement(transformation(extent={{10,-100},{-10,-80}})));
 equation
@@ -83,7 +83,12 @@ equation
           "Resources/Scripts/Dymola/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mos"
         "Simulate and plot"),
     Documentation(revisions="<html>
-<ul>
+    <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li>    
 <li>
 August 9, 2022, by Filip Jorissen:<br/>
 Updated test for issue

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/LongwaveHeatTransfer.mo
@@ -9,7 +9,7 @@ model LongwaveHeatTransfer
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   IDEAS.Buildings.Components.BaseClasses.RadiativeHeatTransfer.ZoneLwDistribution
     zonLwDist(nSurf=2,
-    ignAss=true,       linearise=false)
+    ignAss=true, linearise=false)
     "Model for longwave radiative heat exchange within a zone"
     annotation (Placement(transformation(extent={{10,-80},{-10,-60}})));
   Modelica.Blocks.Sources.Ramp ramp(

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/ZoneLwDistribution.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/Examples/ZoneLwDistribution.mo
@@ -49,7 +49,7 @@ equation
   connect(ramp.y,preTem. T)
     annotation (Line(points={{-79,0},{-62,0}}, color={0,0,127}));
   connect(preTem.port, zonLwDist.port_a[1]) annotation (Line(points={{-40,0},{
-          -20,0},{-20,69.1667},{-10,69.1667}},
+          -20,0},{-20,69.5833},{-10,69.5833}},
                                            color={191,0,0}));
   for i in 2:6 loop
     connect(fixTem.port, zonLwDist.port_a[i]) annotation (Line(points={{-40,70},

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/ZoneLwDistribution.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/ZoneLwDistribution.mo
@@ -80,14 +80,20 @@ initial equation
       else
         ((ones(nSurf) - epsLw) ./ (A .* epsLw) + (ones(nSurf) - F2) ./ A)/Modelica.Constants.sigma;
 
-  // Throw a warning when the simplified approach is used.
-  assert(max(F1)<FMax*0.9 and computeCarroll or simVieFac,
-          "WARNING: In " +getInstanceName() + ": The computed view factor returned unexpected results. 
-          A simplified method is used. 
-          This may be caused by trying to model a non-physical geometry. 
-          Avoid this warning by setting simVieFac=true in the respective zone model.\n",
+  // Throw a warning when the Carroll method returned an out of bounds solution and the simplified approach is used.
+  assert(max(F1)<FMax*0.9,
+          "WARNING: In " +getInstanceName() + ": The view factor computed with Carroll's method returned unexpected results.
+          This may be caused by trying to model a non-physical geometry.
+          A simplified method is used instead. 
+          You can avoid this warning by setting simVieFac=true in the respective zone model.\n",
           AssertionLevel.warning);
 
+  // Throw an error when the simplified approach returns a larger than unity view factor.
+  assert(computeCarroll or max(F2)<1,
+          "ERROR: In " +getInstanceName() + ": The view factor computed with the simplified method returned a larger than unity view factor. 
+          This may be caused by trying to model a non-physical geometry.
+          Please check the geometry of the respective zone model.\n",
+          AssertionLevel.error);
 
 equation
   for i in 1:nSurf loop
@@ -178,7 +184,7 @@ leading to a star resistance network.
 </p>
 <h4>Parameters</h4>
 <p>
-Parameter <code>simVieFac</code> may be set to false to simplify the 
+Parameter <code>simVieFac</code> may be set to true to simplify the 
 view factor calculation. This leads to a less accurate computation
 of view factors, but this approach is more robust.
 It may be used when the initial equation that computes the view factors does not converge.
@@ -186,10 +192,14 @@ It may be used when the initial equation that computes the view factors does not
 <h4>References</h4>
 <p>
 Liesen, R. J., &amp; Pedersen, C. O. (1997). An Evaluation of Inside Surface Heat Balance Models for Cooling Load Calculations. ASHRAE Transactions, 3(103), 485-502.<br/>
-Carroll, J.A. 1980. An \"MRT method\" of computing radiant energy exchange in rooms. Proceedings of the 2nd Sys- tems Simulation and Economics Analysis Conference, January 23-25
+Carroll, J.A. 1980. An \"MRT method\" of computing radiant energy exchange in rooms. Proceedings of the 2nd Systems Simulation and Economics Analysis Conference, January 23-25
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 25, 2024 by Jelger Jansen:<br/>
+Improved asserts when view factor computation returns odd results.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 <li>
 February 18, 2020 by Filip Jorissen:<br/>
 Improved warning when view factor computation returns odd results.

--- a/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/ZoneLwDistribution.mo
+++ b/IDEAS/Buildings/Components/BaseClasses/RadiativeHeatTransfer/ZoneLwDistribution.mo
@@ -3,6 +3,7 @@ model ZoneLwDistribution "internal longwave radiative heat exchange"
 
   parameter Integer nSurf(min=1) "Number of surfaces connected to the zone";
   parameter Boolean simVieFac = false "Simplify view factor computation";
+  parameter Boolean ignAss = false "Ignore asserts to simulate non-physical unit test models";
   parameter Boolean linearise=true "Linearise radiative heat exchange";
   parameter Modelica.Units.SI.Temperature Tzone_nom=295.15
     "Nominal temperature of environment, used for linearisation"
@@ -89,7 +90,7 @@ initial equation
           AssertionLevel.warning);
 
   // Throw an error when the simplified approach returns a larger than unity view factor.
-  assert(computeCarroll or max(F2)<1,
+  assert(computeCarroll or max(F2)<1 or ignAss,
           "ERROR: In " +getInstanceName() + ": The view factor computed with the simplified method returned a larger than unity view factor. 
           This may be caused by trying to model a non-physical geometry.
           Please check the geometry of the respective zone model.\n",
@@ -197,9 +198,10 @@ Carroll, J.A. 1980. An \"MRT method\" of computing radiant energy exchange in ro
 </html>", revisions="<html>
 <ul>
 <li>
-April 25, 2024 by Jelger Jansen:<br/>
+April 26, 2024 by Jelger Jansen:<br/>
 Improved asserts when view factor computation returns odd results.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li>
 <li>
 February 18, 2020 by Filip Jorissen:<br/>
 Improved warning when view factor computation returns odd results.

--- a/IDEAS/Buildings/Components/Examples/CavityWalls.mo
+++ b/IDEAS/Buildings/Components/Examples/CavityWalls.mo
@@ -15,7 +15,8 @@ model CavityWalls
     redeclare package Medium = Medium,
     allowFlowReversal=true,
     V=20,
-    nSurf=2)
+    nSurf=2,
+    ignAss=true)
          annotation (Placement(transformation(extent={{20,-70},{40,-50}})));
   IDEAS.Buildings.Components.OuterWall outerWall(
     inc=IDEAS.Types.Tilt.Wall,
@@ -34,11 +35,11 @@ model CavityWalls
     annotation (Placement(transformation(extent={{-56,-60},{-46,-40}})));
 equation
   connect(outerWall.propsBus_a, zone1.propsBus[2]) annotation (Line(
-      points={{-46.8333,-8},{20,-8},{20,-16},{20,-57}},
+      points={{-46.8333,-8},{20,-8},{20,-55.5},{20,-55.5}},
       color={255,204,51},
       thickness=0.5));
   connect(win.propsBus_a, zone1.propsBus[1]) annotation (Line(
-      points={{-46.8333,-48},{-46.8333,-48},{20,-48},{20,-55}},
+      points={{-46.8333,-48},{-46.8333,-48},{20,-48},{20,-56.5}},
       color={255,204,51},
       thickness=0.5));
   connect(zone1.port_a, bou.ports[1])
@@ -49,6 +50,11 @@ equation
         "Simulate and plot"),
     Documentation(revisions="<html>
 <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li> 
 <li>
 February 10, 2016, by Filip Jorissen:<br/>
 Improved documentation and implementation.

--- a/IDEAS/Buildings/Components/Examples/CavityWalls.mo
+++ b/IDEAS/Buildings/Components/Examples/CavityWalls.mo
@@ -52,7 +52,7 @@ equation
 <ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Set parameter to ignore view factor assert.
+Set parameter <code>ignAss</code> to ignore view factor assert.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li> 
 <li>

--- a/IDEAS/Buildings/Components/Examples/WindowLinearisation.mo
+++ b/IDEAS/Buildings/Components/Examples/WindowLinearisation.mo
@@ -20,7 +20,8 @@ model WindowLinearisation
     redeclare package Medium = Medium,
     allowFlowReversal=true,
     V=20,
-    nSurf=3)
+    nSurf=3,
+    ignAss=true)
          annotation (Placement(transformation(extent={{20,-70},{40,-50}})));
   Window winNonLin(
     A=1,
@@ -42,7 +43,7 @@ model WindowLinearisation
     annotation (Placement(transformation(extent={{-54,-60},{-44,-40}})));
 equation
   connect(zone1.propsBus[1], outerWall.propsBus_a) annotation (Line(
-      points={{20,-54.6667},{20,-54.6667},{20,-6},{20,32},{-44.8333,32}},
+      points={{20,-56.6667},{20,-56.6667},{20,-6},{20,32},{-44.8333,32}},
       color={255,204,51},
       thickness=0.5));
   connect(winNonLin.propsBus_a, zone1.propsBus[2]) annotation (Line(
@@ -50,7 +51,7 @@ equation
       color={255,204,51},
       thickness=0.5));
   connect(winLin.propsBus_a, zone1.propsBus[3]) annotation (Line(
-      points={{-44.8333,-48},{-44.8333,-48},{20,-48},{20,-57.3333}},
+      points={{-44.8333,-48},{-44.8333,-48},{20,-48},{20,-55.3333}},
       color={255,204,51},
       thickness=0.5));
   connect(zone1.port_a, bou.ports[1])
@@ -61,6 +62,11 @@ equation
         "Simulate and plot"),
     Documentation(revisions="<html>
 <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li>    
 <li>
 July 18, 2016, by Filip Jorissen:<br/>
 Updated code and documentation.

--- a/IDEAS/Buildings/Components/Examples/WindowLinearisation.mo
+++ b/IDEAS/Buildings/Components/Examples/WindowLinearisation.mo
@@ -64,7 +64,7 @@ equation
 <ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Set parameter to ignore view factor assert.
+Set parameter <code>ignAss</code> to ignore view factor assert.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li>    
 <li>

--- a/IDEAS/Buildings/Components/Examples/WindowThermalBridge.mo
+++ b/IDEAS/Buildings/Components/Examples/WindowThermalBridge.mo
@@ -22,7 +22,8 @@ model WindowThermalBridge "Comparison of three window thermal bridge options"
     redeclare package Medium = Medium,
     allowFlowReversal=true,
     V=20,
-    nSurf=3)
+    nSurf=3,
+    ignAss=true)
     "Zone model"
     annotation (Placement(transformation(extent={{20,-70},{40,-50}})));
   IDEAS.Buildings.Components.Window win(
@@ -43,7 +44,7 @@ model WindowThermalBridge "Comparison of three window thermal bridge options"
     annotation (Placement(transformation(extent={{-54,-60},{-44,-40}})));
 equation
   connect(zone.propsBus[1], floor.propsBus_a) annotation (Line(
-      points={{20,-54.6667},{20,-54.6667},{20,-6},{20,32},{-44.8333,32}},
+      points={{20,-56.6667},{20,-56.6667},{20,-6},{20,32},{-44.8333,32}},
       color={255,204,51},
       thickness=0.5));
   connect(win.propsBus_a, zone.propsBus[2]) annotation (Line(
@@ -51,7 +52,7 @@ equation
       color={255,204,51},
       thickness=0.5));
   connect(winLinLos.propsBus_a, zone.propsBus[3]) annotation (Line(
-      points={{-44.8333,-48},{-44.8333,-48},{20,-48},{20,-57.3333}},
+      points={{-44.8333,-48},{-44.8333,-48},{20,-48},{20,-55.3333}},
       color={255,204,51},
       thickness=0.5));
   connect(zone.port_a, bou.ports[1])
@@ -62,6 +63,11 @@ equation
         "Simulate and plot"),
     Documentation(revisions="<html>
 <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li> 
 <li>
 December 19, 2016 by Filip Jorissen:<br/>
 Revised implementation.

--- a/IDEAS/Buildings/Components/Examples/WindowThermalBridge.mo
+++ b/IDEAS/Buildings/Components/Examples/WindowThermalBridge.mo
@@ -65,7 +65,7 @@ equation
 <ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Set parameter to ignore view factor assert.
+Set parameter <code>ignAss</code> to ignore view factor assert.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li> 
 <li>

--- a/IDEAS/Buildings/Components/Examples/ZoneStatic.mo
+++ b/IDEAS/Buildings/Components/Examples/ZoneStatic.mo
@@ -51,5 +51,14 @@ equation
       Tolerance=1e-06,
       __Dymola_Algorithm="Lsodar"),
     __Dymola_Commands(file="Resources/Scripts/Dymola/Buildings/Components/Examples/ZoneStatic.mos"
-        "Simulate and plot"));
+        "Simulate and plot"),
+    Documentation(revisions="<html>
+<ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter <code>ignAss</code> to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li> 
+</ul>
+</html>"));
 end ZoneStatic;

--- a/IDEAS/Buildings/Components/Examples/ZoneStatic.mo
+++ b/IDEAS/Buildings/Components/Examples/ZoneStatic.mo
@@ -9,7 +9,8 @@ model ZoneStatic "Zone with constant boundary conditions"
     allowFlowReversal=true,
     V=20,
     nSurf=2,
-    n50=0.01)
+    n50=0.01,
+    ignAss=true)
           "First zone"
     annotation (Placement(transformation(extent={{20,0},{40,20}})));
   IDEAS.Buildings.Components.Interfaces.DummyConnection dummyConnection(
@@ -32,17 +33,17 @@ model ZoneStatic "Zone with constant boundary conditions"
     annotation (Placement(transformation(extent={{0,40},{20,60}})));
 equation
   connect(zone.propsBus[1], dummyConnection.zoneBus) annotation (Line(
-      points={{20,15},{12,15},{-20,15},{-20,-10.2}},
+      points={{20,13.5},{12,13.5},{-20,13.5},{-20,-10.2}},
       color={255,204,51},
       thickness=0.5));
   connect(dummyConnection1.zoneBus, zone.propsBus[2]) annotation (Line(
-      points={{-20,29.8},{-20,13},{20,13}},
+      points={{-20,29.8},{-20,14.5},{20,14.5}},
       color={255,204,51},
       thickness=0.5));
   connect(zone.ports[1], sin.ports[1]) annotation (Line(points={{30,20},{30,46},
-          {20,46},{20,52}},color={0,127,255}));
+          {20,46},{20,49}},color={0,127,255}));
   connect(zone.ports[2], sou.ports[1])
-    annotation (Line(points={{30,20},{32,20},{32,60}}, color={0,127,255}));
+    annotation (Line(points={{30,20},{29,20},{29,60}}, color={0,127,255}));
   annotation (Icon(coordinateSystem(preserveAspectRatio=false)), Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     experiment(

--- a/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
@@ -60,6 +60,8 @@ model PartialZone "Building zone model"
       enable=linIntRad));
   parameter Boolean simVieFac=false "Simplify view factor computation"
     annotation(Dialog(tab="Advanced", group="Radiative heat exchange"));
+  parameter Boolean ignAss=false "Simplify view factor computation"
+    annotation(Dialog(tab="Advanced", group="Radiative heat exchange"));
 
   replaceable ZoneAirModels.WellMixedAir airModel
   constrainedby
@@ -217,7 +219,8 @@ protected
     radDistrLw(nSurf=nSurf, final linearise=linIntRad or sim.linearise,
     Tzone_nom=Tzone_nom,
     dT_nom=dT_nom,
-    final simVieFac=simVieFac)                if not calculateViewFactor
+    final simVieFac=simVieFac,
+    final ignAss=ignAss)                if not calculateViewFactor
     "internal longwave radiative heat exchange" annotation (Placement(
         transformation(
         extent={{10,-10},{-10,10}},
@@ -509,6 +512,11 @@ end for;
 <p>See extending models.</p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Added parameter to ignore view factor asserts for non-physical unit test models.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li> 
 <li>
 January 8, 2024, by Jelger Jansen:<br/>
 Added min attribute to <code>mSenFac</code>.

--- a/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
@@ -60,7 +60,7 @@ model PartialZone "Building zone model"
       enable=linIntRad));
   parameter Boolean simVieFac=false "Simplify view factor computation"
     annotation(Dialog(tab="Advanced", group="Radiative heat exchange"));
-  parameter Boolean ignAss=false "Simplify view factor computation"
+  parameter Boolean ignAss=false "Ignore asserts to simulate non-physical unit test models"
     annotation(Dialog(tab="Advanced", group="Radiative heat exchange"));
 
   replaceable ZoneAirModels.WellMixedAir airModel

--- a/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
+++ b/IDEAS/Buildings/Components/Interfaces/PartialZone.mo
@@ -514,7 +514,7 @@ end for;
 <ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Added parameter to ignore view factor asserts for non-physical unit test models.
+Added parameter <code>ignAss</code> to ignore view factor asserts for non-physical unit test models.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li> 
 <li>

--- a/IDEAS/Buildings/Examples/ZoneExample.mo
+++ b/IDEAS/Buildings/Examples/ZoneExample.mo
@@ -14,6 +14,7 @@ model ZoneExample
     allowFlowReversal=true,
     nSurf=3,
     V=l*w*h,
+    ignAss=true,
     redeclare Components.InterzonalAirFlow.AirTight interzonalAirFlow)
           "First zone"
     annotation (Placement(transformation(extent={{0,-40},{20,-20}})));
@@ -54,6 +55,7 @@ model ZoneExample
     allowFlowReversal=true,
     nSurf=4,
     V=l*w*h,
+    ignAss=true,
     redeclare Components.InterzonalAirFlow.AirTight interzonalAirFlow)
           "Second zone"
     annotation (Placement(transformation(extent={{0,20},{20,40}})));
@@ -71,7 +73,7 @@ model ZoneExample
     annotation (Placement(transformation(extent={{-56,60},{-44,80}})));
 equation
   connect(internalWall.propsBus_a, zone.propsBus[1]) annotation (Line(
-      points={{-10,-5},{-10,-24.6667},{0,-24.6667}},
+      points={{-10,-5},{-10,-26.6667},{0,-26.6667}},
       color={255,204,51},
       thickness=0.5));
   connect(slabOnGround.propsBus_a, zone.propsBus[2]) annotation (Line(
@@ -79,23 +81,23 @@ equation
       color={255,204,51},
       thickness=0.5));
   connect(outerWall.propsBus_a, zone.propsBus[3]) annotation (Line(
-      points={{-45,-48},{-20,-48},{-20,-27.3333},{0,-27.3333}},
+      points={{-45,-48},{-20,-48},{-20,-25.3333},{0,-25.3333}},
       color={255,204,51},
       thickness=0.5));
   connect(Roof.propsBus_a, zone1.propsBus[1]) annotation (Line(
-      points={{-45,72},{-45,72},{-12,72},{-12,35.5},{0,35.5}},
+      points={{-45,72},{-45,72},{-12,72},{-12,33.25},{0,33.25}},
       color={255,204,51},
       thickness=0.5));
   connect(window.propsBus_a, zone1.propsBus[2]) annotation (Line(
-      points={{-45,52},{-45,52},{-14,52},{-14,34.5},{0,34.5}},
+      points={{-45,52},{-45,52},{-14,52},{-14,33.75},{0,33.75}},
       color={255,204,51},
       thickness=0.5));
   connect(outerWall1.propsBus_a, zone1.propsBus[3]) annotation (Line(
-      points={{-45,32},{-14,32},{-14,33.5},{0,33.5}},
+      points={{-45,32},{-14,32},{-14,34.25},{0,34.25}},
       color={255,204,51},
       thickness=0.5));
   connect(internalWall.propsBus_b, zone1.propsBus[4]) annotation (Line(
-      points={{-10,5},{-12,5},{-12,32.5},{0,32.5}},
+      points={{-10,5},{-12,5},{-12,34.75},{0,34.75}},
       color={255,204,51},
       thickness=0.5));
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
@@ -104,6 +106,11 @@ equation
         "Simulate and plot"),
     Documentation(revisions="<html>
 <ul>
+<li>
+April 26, 2024 by Jelger Jansen:<br/>
+Set parameter to ignore view factor assert.
+This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
+</li>  
 <li>
 January 2, 2017 by Filip Jorissen:<br/>
 Revised implementation.

--- a/IDEAS/Buildings/Examples/ZoneExample.mo
+++ b/IDEAS/Buildings/Examples/ZoneExample.mo
@@ -108,7 +108,7 @@ equation
 <ul>
 <li>
 April 26, 2024 by Jelger Jansen:<br/>
-Set parameter to ignore view factor assert.
+Set parameter <code>ignAss</code> to ignore view factor assert.
 This is for <a href=https://github.com/open-ideas/IDEAS/issues/1272>#1272</a>.
 </li>  
 <li>


### PR DESCRIPTION
Change conditions of existing warning such that this one only appears if the `computeCarroll=true` and `max(F1)>FMax*0.9`. If `computeCarroll=false` (due to `simVieFac=true` or `max(A)>sum(A)/2`), The values of `F1` are equal to 0, so the warning is never thrown in that case. Furthermore, an extra assert is added which throws a warning in case `computeCarroll=false` AND `max(F2)>1`.  This is for #1272.

@Mathadon let me know if you think there is still something wrong with these warning (I cannot add you as a reviewer).