### PR TITLE
Issue1437 Fix OM scripting errors

### DIFF
--- a/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
+++ b/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
@@ -1550,7 +1550,7 @@ components cannot be propagated.
 <ul>
 <li>
 June 13, 2025, by Jelger Jansen:<br/>
-Add parameter <code>hasCavity</code> as it is used in the enabling of some parameters.
+Add parameter <code>hasCavity</code> as it is used in the enabling of some parameters and fix typo <code>bouTyp</code>.
 See <a href=\"https://github.com/open-ideas/IDEAS/issues/1437\">#1437</a>.
 </li>
 <li>

--- a/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
+++ b/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
@@ -1099,6 +1099,9 @@ protected
   final parameter Integer indWinD = indWinC + (if hasWinD then 1 else 0);
   final parameter Integer indWinCei = indWinD + (if hasWinCei then 1 else 0);
 
+  final parameter Boolean hasCavity = hasCavityA or hasCavityB or hasCavityC or hasCavityD or hasCavityFlo
+    "Boolean to enable open door modelling parameters if the RectangularZone has a cavity";
+
 initial equation
   assert(not bouTypA==IDEAS.Buildings.Components.Interfaces.BoundaryType.SlabOnGround,
     "The value for bouTypA is not supported");
@@ -1545,6 +1548,11 @@ components cannot be propagated.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+June 13, 2025, by Jelger Jansen:<br/>
+Add parameter <code>hasCavity</code> as it is used in the enabling of some parameters.
+See <a href=\"https://github.com/open-ideas/IDEAS/issues/1437\">#1437</a>.
+</li>
 <li>
 February 4, 2025, by Jelger Jansen:<br/>
 Added <code>Modelica.Units.</code> to one or multiple parameter(s) due to the removal of <code>import</code> in IDEAS/package.mo.

--- a/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
+++ b/IDEAS/Buildings/Components/Interfaces/RectangularZoneTemplateInterface.mo
@@ -396,7 +396,7 @@ partial model RectangularZoneTemplateInterface
   // open door modelling
   parameter Boolean hasCavityA = false
     "=true, to model open door or cavity in internal wall"
-    annotation(Dialog(tab="Face A", group="Cavity or open door", enable=(bouTypeA==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
+    annotation(Dialog(tab="Face A", group="Cavity or open door", enable=(bouTypA==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
   parameter Modelica.Units.SI.Length hA(min=0) = 2
     "Height of (rectangular) cavity in internal wall" annotation (Dialog(
       enable=hasCavityA,
@@ -409,7 +409,7 @@ partial model RectangularZoneTemplateInterface
       group="Cavity or open door"));
   parameter Boolean hasCavityB = false
     "=true, to model open door or cavity in internal wall"
-    annotation(Dialog(tab="Face B", group="Cavity or open door", enable=(bouTypeB==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
+    annotation(Dialog(tab="Face B", group="Cavity or open door", enable=(bouTypB==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
   parameter Modelica.Units.SI.Length hB(min=0) = 2
     "Height of (rectangular) cavity in internal wall" annotation (Dialog(
       enable=hasCavityB,
@@ -422,7 +422,7 @@ partial model RectangularZoneTemplateInterface
       group="Cavity or open door"));
   parameter Boolean hasCavityC = false
     "=true, to model open door or cavity in internal wall"
-    annotation(Dialog(tab="Face C", group="Cavity or open door", enable=(bouTypeC==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
+    annotation(Dialog(tab="Face C", group="Cavity or open door", enable=(bouTypC==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
   parameter Modelica.Units.SI.Length hC(min=0) = 2
     "Height of (rectangular) cavity in internal wall" annotation (Dialog(
       enable=hasCavityC,
@@ -435,7 +435,7 @@ partial model RectangularZoneTemplateInterface
       group="Cavity or open door"));
   parameter Boolean hasCavityD = false
     "=true, to model open door or cavity in internal wall"
-    annotation(Dialog(tab="Face D", group="Cavity or open door", enable=(bouTypeD==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
+    annotation(Dialog(tab="Face D", group="Cavity or open door", enable=(bouTypD==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
   parameter Modelica.Units.SI.Length hD(min=0) = 2
     "Height of (rectangular) cavity in internal wall" annotation (Dialog(
       enable=hasCavityD,
@@ -448,7 +448,7 @@ partial model RectangularZoneTemplateInterface
       group="Cavity or open door"));
   parameter Boolean hasCavityFlo = false
     "=true, to model open door or cavity in internal floor"
-    annotation(Dialog(tab="Floor", group="Cavity or open door", enable=(bouTypeFlo==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
+    annotation(Dialog(tab="Floor", group="Cavity or open door", enable=(bouTypFlo==IDEAS.Buildings.Components.Interfaces.BoundaryType.InternalWall)));
   parameter Modelica.Units.SI.Length bFlo(min=0) = 2
     "Breadth of (rectangular) cavity in internal floor" annotation (Dialog(
       enable=hasCavityFlo,

--- a/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlow.mo
+++ b/IDEAS/Buildings/Components/InterzonalAirFlow/BaseClasses/PartialInterzonalAirFlow.mo
@@ -18,6 +18,7 @@ partial model PartialInterzonalAirFlow "Partial for interzonal air flow"
   parameter Modelica.Units.SI.MassFlowRate m_flow_nominal_vent
     "Nominal mass flow rate of ventilation system"
     annotation (Dialog(tab="Advanced"));
+
   Modelica.Fluid.Interfaces.FluidPort_b port_b_interior(
     redeclare package Medium = Medium,
     m_flow(nominal=m_flow_nominal_vent),
@@ -67,29 +68,21 @@ equation
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
         Rectangle(
-          extent={{-15,80},{15,-80}},
+          extent={{-100,100},{60,70}},
           fillColor={192,192,192},
           fillPattern=FillPattern.Backward,
-          pattern=LinePattern.None,
-          origin={-19,86},
-          rotation=90),
+          pattern=LinePattern.None),
         Rectangle(
           extent={{-70,100},{-100,40}},
           fillColor={192,192,192},
           fillPattern=FillPattern.Backward,
           pattern=LinePattern.None),
         Line(
-          points={{57.5,0},{-11,-0.5}},
-          color={0,128,255},
-          visible=not allowFlowReversal,
-          origin={-20.5,31},
-          rotation=90),
+          points={{-20,20},{-20,90}},
+          color={0,128,255}),
         Line(
-          points={{57.5,0},{-13,-0.5}},
-          color={0,128,255},
-          visible=not allowFlowReversal,
-          origin={19.5,33},
-          rotation=90),
+          points={{20,20},{20,90}},
+          color={0,128,255}),
         Rectangle(
           extent={{-70,0},{-100,-60}},
           fillColor={192,192,192},
@@ -100,8 +93,7 @@ equation
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={20,41},
+          origin={20,40},
           rotation=270),
         Line(
           points={{60,70},{-70,70},{-70,-60}},
@@ -113,12 +105,17 @@ equation
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={-20,69},
+          origin={-20,70},
           rotation=90)}),                                        Diagram(
         coordinateSystem(preserveAspectRatio=false)),
     Documentation(revisions="<html>
 <ul>
+<li>
+June 13, 2025, Jelger Jansen:<br/>
+Remove <code>visible=not allowFlowReversal</code> in annotation of icon elements.
+Improve placement of icon elements.
+See <a href=\"https://github.com/open-ideas/IDEAS/issues/1437\">#1437</a>.
+</li>
 <li>
 March 17, 2020, Filip Jorissen:<br/>
 Added support for vector fluidport.

--- a/IDEAS/Buildings/Components/InterzonalAirFlow/FixedPressure.mo
+++ b/IDEAS/Buildings/Components/InterzonalAirFlow/FixedPressure.mo
@@ -14,6 +14,12 @@ equation
   annotation (Documentation(revisions="<html>
 <ul>
 <li>
+June 13, 2025, Jelger Jansen:<br/>
+Remove <code>visible=not allowFlowReversal</code> in annotation of icon elements.
+Improve placement of icon elements.
+See <a href=\"https://github.com/open-ideas/IDEAS/issues/1437\">#1437</a>.
+</li>
+<li>
 March 17, 2020, Filip Jorissen:<br/>
 Added support for vector fluidport.
 See <a href=\"https://github.com/open-ideas/IDEAS/issues/1029\">#1029</a>.
@@ -45,21 +51,16 @@ from the environment with the ambient temperature and humidity.
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={-118,19},
+          origin={-115.5,20},
           rotation=180),
         Polygon(
           points={{-11,10},{20,0},{-11,-10},{-11,10}},
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={-54,19},
+          origin={-54.5,20},
           rotation=360),
         Line(
-          points={{57.5,0},{-11,-0.5}},
-          color={0,128,255},
-          visible=not allowFlowReversal,
-          origin={-60.5,19},
-          rotation=180)}));
+          points={{-120,20},{-50,20}},
+          color={0,128,255})}));
 end FixedPressure;

--- a/IDEAS/Buildings/Components/InterzonalAirFlow/n50FixedPressure.mo
+++ b/IDEAS/Buildings/Components/InterzonalAirFlow/n50FixedPressure.mo
@@ -14,6 +14,12 @@ equation
   annotation (Documentation(revisions="<html>
 <ul>
 <li>
+June 13, 2025, Jelger Jansen:<br/>
+Remove <code>visible=not allowFlowReversal</code> in annotation of icon elements.
+Improve placement of icon elements.
+See <a href=\"https://github.com/open-ideas/IDEAS/issues/1437\">#1437</a>.
+</li>
+<li>
 March 17, 2020, Filip Jorissen:<br/>
 Added support for vector fluidport.
 See <a href=\"https://github.com/open-ideas/IDEAS/issues/1029\">#1029</a>.
@@ -50,21 +56,16 @@ The mass flow rate is computed from the zone <code>n50</code> value.
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={-54,19},
+          origin={-54.5,20},
           rotation=360),
         Line(
-          points={{57.5,0},{-11,-0.5}},
-          color={0,128,255},
-          visible=not allowFlowReversal,
-          origin={-60.5,19},
-          rotation=180),
+          points={{-120,20},{-50,20}},
+          color={0,128,255}),
         Polygon(
           points={{-11,10},{20,0},{-11,-10},{-11,10}},
           lineColor={0,128,255},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not allowFlowReversal,
-          origin={-118,19},
+          origin={-115.5,20},
           rotation=180)}));
 end n50FixedPressure;


### PR DESCRIPTION
Avoid scripting errors in OM due to the inexistence of some parameters in the enabling of parameters in the diagram view and the visibility of icons.