### PR TITLE
Add missing replaceable.

### DIFF
--- a/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
+++ b/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
@@ -1,6 +1,6 @@
 within IDEAS.Templates.Examples;
 model IdealRadiatorHeating "Example and test for ideal heating with radiators"
-  extends IDEAS.Templates.Examples.BaseClasses.SimpleHeatingsystem(replaceable
+extends IDEAS.Templates.Examples.BaseClasses.SimpleHeatingsystem(redeclare replaceable
       Heating.IdealRadiatorHeating heating);
 
 equation

--- a/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
+++ b/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
@@ -24,7 +24,11 @@ Model that demonstrates the use of the
 IDEAS.Templates.Heating.IdealRadiatorHeating</a>.
 </p>
 </html>",     revisions="<html>
-<ul>
+<li>
+May 20, 2026 by Anna Dell'Isola:<br/>
+Add replaceable in redeclare. See 
+<a href=\"https://github.com/open-ideas/IDEAS/pull/1493\">#1493</a>.
+</li>
 <li>
 June 5, 2018 by Filip Jorissen:<br/>
 Cleaned up implementation for

--- a/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
+++ b/IDEAS/Templates/Examples/IdealRadiatorHeating.mo
@@ -1,6 +1,6 @@
 within IDEAS.Templates.Examples;
 model IdealRadiatorHeating "Example and test for ideal heating with radiators"
-  extends IDEAS.Templates.Examples.BaseClasses.SimpleHeatingsystem(redeclare
+  extends IDEAS.Templates.Examples.BaseClasses.SimpleHeatingsystem(replaceable
       Heating.IdealRadiatorHeating heating);
 
 equation


### PR DESCRIPTION
`IDEAS.Templates.Examples.RadiatorHeating` extends `IDEAS.Templates.Examples.IdealRadiatorHeating` and redeclares `heating`.
Unfortunately, in `IDEAS.Templates.Examples.IdealRadiatorHeating`, `heating` is redeclared without the `replaceable` keyword.

This PR adds the missing keyword.