### PR TITLE
Refactor shading connections of PartialShadingDevice

### DIFF
--- a/IDEAS/Buildings/Components/Shading/BuildingShade.mo
+++ b/IDEAS/Buildings/Components/Shading/BuildingShade.mo
@@ -23,6 +23,11 @@ model BuildingShade
 
   // Computation assumes that window base is at ground level.
   // Viewing angle computed from center of glazing.
+  Modelica.Blocks.Sources.RealExpression HShaDirexpr(y=fraSunDir*HDirTil)
+    annotation (Placement(transformation(extent={{-30,40},{-10,60}})));
+  Modelica.Blocks.Sources.RealExpression HShaSkyDifexpr(y=fraSunDifSky*
+        HSkyDifTil)
+    annotation (Placement(transformation(extent={{-30,20},{-10,40}})));
 protected
   parameter Modelica.Units.SI.Angle vieAngObj=atan((hWin/2 + dh)/L)
     "Viewing angle of opposite object";
@@ -57,13 +62,16 @@ equation
     fraSunDir=1;
   end if;
 
-  HShaDirTil=fraSunDir*HDirTil;
-  HShaSkyDifTil = fraSunDifSky*HSkyDifTil;
+
   connect(angInc, iAngInc) annotation (Line(points={{-60,-50},{-14,-50},{-14,-50},
           {40,-50}}, color={0,0,127}));
 
-  connect(HGroDifTil, HShaGroDifTil)
-    annotation (Line(points={{-60,10},{40,10},{40,10}}, color={0,0,127}));
+  connect(HShaDirexpr.y, HShaDir.u)
+    annotation (Line(points={{-9,50},{-1.2,50}}, color={0,0,127}));
+  connect(HShaSkyDifexpr.y, HShaSkyDif.u)
+    annotation (Line(points={{-9,30},{-1.2,30}}, color={0,0,127}));
+  connect(HGroDifTil, HShaSkyGro.u)
+    annotation (Line(points={{-60,10},{-1.2,10}}, color={0,0,127}));
   annotation (
     Icon(coordinateSystem(extent = {{-100, -100}, {100, 200}})),
     Documentation(info="<html>
@@ -95,6 +103,10 @@ can be modelled by changing the value of parameter <code>fraSha</code> according
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 18, 2022 by Filip Jorissen:<br/>
 Refactored for <a href=\"https://github.com/open-ideas/IDEAS/issues/1270\">#1270</a> for including thermal effect of screens.

--- a/IDEAS/Buildings/Components/Shading/HorizontalFins.mo
+++ b/IDEAS/Buildings/Components/Shading/HorizontalFins.mo
@@ -44,6 +44,12 @@ protected
   Modelica.Units.SI.Length dy3Dif=max(0, min(dzDif*tan(angAltDif), s));
   Modelica.Units.SI.Length dzDif=dx/cos(angAltDif);
 
+public
+  Modelica.Blocks.Sources.RealExpression HShaDirexpr(y=(1 - shaFrac)*HDirTil)
+    annotation (Placement(transformation(extent={{-32,40},{-12,60}})));
+  Modelica.Blocks.Sources.RealExpression HShaSkyDifexpr(y=(1 - shaFracDif)*
+        HSkyDifTil)
+    annotation (Placement(transformation(extent={{-32,20},{-12,40}})));
 initial equation
   if not use_betaInput then
     assert(beta >= 0 and beta < acos(t/s), "In " + getInstanceName() + ": Beta must be within the feasible range.");
@@ -84,12 +90,16 @@ equation
     shaFracDif = disp_internal*(1 - (dy1-min(dy1,dy3Dif))/s);
   end if;
 
-  HShaDirTil = (1-shaFrac)*HDirTil;
-  HShaSkyDifTil = (1-shaFracDif)*HSkyDifTil;
 
   angInc = iAngInc;
-  connect(HGroDifTil, HShaGroDifTil);
 
+
+  connect(HGroDifTil, HShaSkyGro.u)
+    annotation (Line(points={{-60,10},{-1.2,10}}, color={0,0,127}));
+  connect(HShaDirexpr.y, HShaDir.u)
+    annotation (Line(points={{-11,50},{-1.2,50}}, color={0,0,127}));
+  connect(HShaSkyDifexpr.y, HShaSkyDif.u)
+    annotation (Line(points={{-11,30},{-1.2,30}}, color={0,0,127}));
     annotation (
     Icon(coordinateSystem(extent = {{-100, -100}, {100, 200}})),
     Documentation(info="<html>
@@ -144,6 +154,10 @@ The implementation is illustrated using this figure:
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 Febrauri 24, 2025 by Filip Jorissen:<br/>
 Added <code>Ctrl_to_beta_internal=0</code> when not using beta input.

--- a/IDEAS/Buildings/Components/Shading/Interfaces/PartialShadingDevice.mo
+++ b/IDEAS/Buildings/Components/Shading/Interfaces/PartialShadingDevice.mo
@@ -30,13 +30,21 @@ partial model PartialShadingDevice
    linearise = linCon) if haveBoundaryPorts annotation (
     Placement(visible = true, transformation(extent = {{12, 104}, {-8, 124}}, rotation = 0)));
   Modelica.Blocks.Math.Add solDif(k1 = 1, k2 = 1) if haveBoundaryPorts and haveFrame annotation (
-    Placement(visible = true, transformation(origin = {90, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin={50,90},    extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Sources.RealExpression TeExpr(y=Te_internal)
     "Expression for Te"
     annotation (Placement(transformation(extent={{-68,178},{-48,198}})));
   Modelica.Blocks.Sources.RealExpression TEnvExpr(y=TEnv_internal)
     "Expression for TEnv"
     annotation (Placement(transformation(extent={{-68,160},{-48,180}})));
+  Modelica.Blocks.Sources.RealExpression TDryBulExp(y=TDryBul_internal)
+    annotation (Placement(transformation(extent={{-20,-20},{0,0}})));
+  Modelica.Blocks.Routing.RealPassThrough HShaDir
+    annotation (Placement(transformation(extent={{0,44},{12,56}})));
+  Modelica.Blocks.Routing.RealPassThrough HShaSkyDif
+    annotation (Placement(transformation(extent={{0,24},{12,36}})));
+  Modelica.Blocks.Routing.RealPassThrough HShaSkyGro
+    annotation (Placement(transformation(extent={{0,4},{12,16}})));
 protected
   Modelica.Blocks.Interfaces.RealInput TDryBul_internal = Te_internal
     "Internal variable to avoid assigning a value to a non-input in the model extends statement";
@@ -48,7 +56,6 @@ equation
     TEnv_internal = 273.15;
   end if;
 
-  connect(TDryBul,TDryBul_internal);
   connect(skyRadFra.port_a, port_frame) annotation (
     Line(points = {{10, 192}, {55, 192}, {55, 160}, {100, 160}}, color = {191, 0, 0}));
   connect(eConFra.port_a, port_frame) annotation (
@@ -57,14 +64,9 @@ equation
     Line(points = {{-12, 172}, {-36, 172}, {-36, 110}, {-60, 110}}, color = {0, 0, 127}));
   connect(solAbs.port_a, port_frame) annotation (
     Line(points = {{10, 160}, {100, 160}}, color = {191, 0, 0}));
-  connect(solDif.u2, HShaGroDifTil) annotation (
-    Line(points = {{78, 24}, {40, 24}, {40, 10}}, color = {0, 0, 127}));
-  connect(solDif.u1, HShaSkyDifTil) annotation (
-    Line(points = {{78, 36}, {40, 36}, {40, 30}}, color = {0, 0, 127}));
   connect(solDif.y, solAbs.solDif) annotation (
-    Line(points = {{101, 30}, {108, 30}, {108, 142}, {-10, 142}, {-10, 162}}, color = {0, 0, 127}));
-  connect(solAbs.solDir, HShaDirTil) annotation (
-    Line(points = {{-10, 166}, {-14, 166}, {-14, 90}, {40, 90}, {40, 50}}, color = {0, 0, 127}));
+    Line(points={{61,90},{64,90},{64,106},{16,106},{16,100},{-18,100},{-18,142},
+          {-20,142},{-20,162},{-10,162}},                                     color = {0, 0, 127}));
   connect(eCon.hForcedConExt, hForcedConExt) annotation (
     Line(points = {{-10, 110}, {-60, 110}}, color = {0, 0, 127}));
   connect(eCon.port_a, port_glazing) annotation (
@@ -79,9 +81,28 @@ equation
           {-24,170},{-47,170}}, color={0,0,127}));
   connect(skyRadFra.Tenv, TEnvExpr.y) annotation (Line(points={{-10,192},{-24,
           192},{-24,170},{-47,170}}, color={0,0,127}));
+  connect(TDryBulExp.y, TDryBul)
+    annotation (Line(points={{1,-10},{40,-10}}, color={0,0,127}));
+  connect(HShaDir.y, HShaDirTil)
+    annotation (Line(points={{12.6,50},{40,50}}, color={0,0,127}));
+  connect(HShaDir.y, solAbs.solDir) annotation (Line(points={{12.6,50},{16,50},
+          {16,98},{-20,98},{-20,112},{-22,112},{-22,166},{-10,166}}, color={0,0,
+          127}));
+  connect(HShaSkyDif.y, HShaSkyDifTil)
+    annotation (Line(points={{12.6,30},{40,30}}, color={0,0,127}));
+  connect(HShaSkyGro.y, HShaGroDifTil)
+    annotation (Line(points={{12.6,10},{40,10}}, color={0,0,127}));
+  connect(HShaSkyDif.y, solDif.u1) annotation (Line(points={{12.6,30},{16,30},{
+          16,96},{38,96}}, color={0,0,127}));
+  connect(HShaSkyGro.y, solDif.u2) annotation (Line(points={{12.6,10},{16,10},{
+          16,84},{38,84}}, color={0,0,127}));
   annotation (
     Documentation(revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Refactored model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 18, 2022, by Filip Jorissen:<br/>
 First implementation.

--- a/IDEAS/Buildings/Components/Shading/None.mo
+++ b/IDEAS/Buildings/Components/Shading/None.mo
@@ -7,14 +7,18 @@ equation
       points={{-60,-50},{-16,-50},{-16,-50},{40,-50}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(HDirTil, HShaDirTil)
-    annotation (Line(points={{-60,50},{40,50},{40,50}}, color={0,0,127}));
-  connect(HSkyDifTil, HShaSkyDifTil) annotation (Line(points={{-60,30},{-17,30},
-          {-17,30},{40,30}}, color={0,0,127}));
-  connect(HGroDifTil, HShaGroDifTil) annotation (Line(points={{-60,10},{-14,10},
-          {-14,10},{40,10}}, color={0,0,127}));
+  connect(HGroDifTil, HShaSkyGro.u)
+    annotation (Line(points={{-60,10},{-1.2,10}}, color={0,0,127}));
+  connect(HSkyDifTil, HShaSkyDif.u)
+    annotation (Line(points={{-60,30},{-1.2,30}}, color={0,0,127}));
+  connect(HDirTil, HShaDir.u)
+    annotation (Line(points={{-60,50},{-1.2,50}}, color={0,0,127}));
   annotation (Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-100, -100}, {100, 200}})), Documentation(revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 18, 2022 by Filip Jorissen:<br/>
 Refactored for <a href=\"https://github.com/open-ideas/IDEAS/issues/1270\">#1270</a> for including thermal effect of screens.

--- a/IDEAS/Buildings/Components/Shading/Overhang.mo
+++ b/IDEAS/Buildings/Components/Shading/Overhang.mo
@@ -59,6 +59,12 @@ protected
   Modelica.Units.SI.Angle verAzi
     "Angle between projection of sun's rays and normal to vertical surface";
 
+public
+  Modelica.Blocks.Sources.RealExpression HShaDirexpr(y=fraSunDir*HDirTil)
+    annotation (Placement(transformation(extent={{-30,40},{-10,60}})));
+  Modelica.Blocks.Sources.RealExpression HShaSkyDifexpr(y=fraSunDifSky*
+        HSkyDifTil)
+    annotation (Placement(transformation(extent={{-30,20},{-10,40}})));
 initial equation
 
     assert(dep > 0, "The depth of the overhang must be larger than zero.");
@@ -94,15 +100,17 @@ equation
   crShdArea=IDEAS.Utilities.Math.Functions.smoothMax(x1=crShdArea1,x2=crShdArea2,deltaX=0.01);
   fraSunDir = IDEAS.Utilities.Math.Functions.smoothMin( x1=IDEAS.Utilities.Math.Functions.smoothMax(x1=1-crShdArea/AWin,x2=0,deltaX=0.01),x2=1.0,deltaX=0.01);
 
-  HShaDirTil = fraSunDir*HDirTil;
-  HShaSkyDifTil=fraSunDifSky*HSkyDifTil;
 
   connect(angInc, iAngInc) annotation (Line(
       points={{-60,-50},{-14,-50},{-14,-50},{40,-50}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(HGroDifTil, HShaGroDifTil) annotation (Line(points={{-60,10},{-14,10},
-          {-14,10},{40,10}}, color={0,0,127}));
+  connect(HShaDirexpr.y, HShaDir.u)
+    annotation (Line(points={{-9,50},{-1.2,50}}, color={0,0,127}));
+  connect(HShaSkyDifexpr.y, HShaSkyDif.u)
+    annotation (Line(points={{-9,30},{-1.2,30}}, color={0,0,127}));
+  connect(HShaSkyGro.u, HGroDifTil)
+    annotation (Line(points={{-1.2,10},{-60,10}}, color={0,0,127}));
   annotation (                   Documentation(info="<html>
 <p>
 Shading model of an overhang above a window where
@@ -115,6 +123,10 @@ and wLeft and wRight are respectively the horizontal overhang widths.
 <p><img alt=\"illustration\" src=\"modelica://IDEAS/Resources/Images/Buildings/Components/Shading/Overhang.png\"/></p>
 </html>", revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 18, 2022 by Filip Jorissen:<br/>
 Refactored for <a href=\"https://github.com/open-ideas/IDEAS/issues/1270\">#1270</a> for including thermal effect of screens.

--- a/IDEAS/Buildings/Components/Shading/Screen.mo
+++ b/IDEAS/Buildings/Components/Shading/Screen.mo
@@ -12,24 +12,38 @@ model Screen "Controllable exterior screen"
     "Shortwave transmittance of the screen";
   parameter Real refSw_shading(min=0, max=1) = 0
     "Shortwave reflectance of the screen";
-    
+
 protected
   constant Modelica.Units.SI.SpecificHeatCapacity cp_air = 1004 "Specific heat capacity";
   Modelica.Units.SI.Temperature TEnv_screen = Ctrl_internal*TSha + (1-Ctrl_internal)*TEnv_internal
     "Assuming the environment temperature is a weighted average of the shading device temperature and the ambient temperature";
   // This assumes that the window rejects 1-g_glazing of the incoming solar irradation is entirely converted into sensible heat
+public
+  Modelica.Blocks.Sources.RealExpression HShaDirexpr(y=HDirTil*((1 -
+        Ctrl_internal) + Ctrl_internal*shaCorr))
+    annotation (Placement(transformation(extent={{-30,38},{-10,58}})));
+  Modelica.Blocks.Sources.RealExpression HShaSkyDifexpr(y=HSkyDifTil*((1 -
+        Ctrl_internal) + Ctrl_internal*shaCorr))
+    annotation (Placement(transformation(extent={{-30,18},{-10,38}})));
+  Modelica.Blocks.Sources.RealExpression HShaGroDifexpr(y=HGroDifTil*((1 -
+        Ctrl_internal) + Ctrl_internal*shaCorr))
+    annotation (Placement(transformation(extent={{-30,-2},{-10,18}})));
+protected
   Modelica.Units.SI.Temperature TShaScreen = Te_internal + (HSha*(1-g_glazing) + (H - HSha) * epsSw_shading) /(hSha + abs(m_flow)*cp_air)
     "Modified shading device heat balance";
 initial equation
   assert( abs(shaCorr + refSw_shading + epsSw_shading - 1) < 1e-3, "In " + getInstanceName() +
     ": The sum of the screen transmittance 'shaCorr', reflectance 'refSw_shading' and absorptance 'epsSw_shading' does not equal one. This is non-physical.");
 equation
-  HShaDirTil = HDirTil*((1 - Ctrl_internal) + Ctrl_internal*shaCorr);
-  HShaSkyDifTil = HSkyDifTil*((1 - Ctrl_internal) + Ctrl_internal*shaCorr);
-  HShaGroDifTil = HGroDifTil*((1 - Ctrl_internal) + Ctrl_internal*shaCorr);
 
   connect(angInc, iAngInc) annotation (Line(points={{-60,-50},{-14,-50},{-14,
           -50},{40,-50}}, color={0,0,127}));
+  connect(HShaDirexpr.y, HShaDir.u)
+    annotation (Line(points={{-9,48},{-8,50},{-1.2,50}}, color={0,0,127}));
+  connect(HShaSkyDifexpr.y, HShaSkyDif.u)
+    annotation (Line(points={{-9,28},{-8,30},{-1.2,30}}, color={0,0,127}));
+  connect(HShaGroDifexpr.y, HShaSkyGro.u)
+    annotation (Line(points={{-9,8},{-8,10},{-1.2,10}}, color={0,0,127}));
   annotation (
     Icon(coordinateSystem(extent = {{-100, -100}, {100, 200}})),
     Documentation(info="<html>
@@ -40,6 +54,10 @@ A fraction <code>shaCorr</code> is converted into diffuse light that enters the 
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 26, 2024 by Jelger Jansen:<br/>
 Replace <code>Ctrl</code> by <code>Ctrl_internal</code> to avoid using a conditional component in a connect statement.

--- a/IDEAS/Buildings/Components/Shading/SideFins.mo
+++ b/IDEAS/Buildings/Components/Shading/SideFins.mo
@@ -61,6 +61,13 @@ protected
   Real verAzi;
   Real lambda;
 
+public
+  Modelica.Blocks.Sources.RealExpression HShaDirexpr(y=HDirTil*fraSunDir)
+    annotation (Placement(transformation(extent={{-30,40},{-10,60}})));
+  Modelica.Blocks.Sources.RealExpression HShaSkyDifexpr(y=fraSunDif*HSkyDifTil)
+    annotation (Placement(transformation(extent={{-30,20},{-10,40}})));
+  Modelica.Blocks.Sources.RealExpression HShaGroDifexpr(y=fraSunDif*HGroDifTil)
+    annotation (Placement(transformation(extent={{-30,0},{-10,20}})));
 initial equation
 
     assert(dep > 0, "The depth of the sidefins must be larger than zero.");
@@ -90,14 +97,18 @@ equation
   crShdArea=IDEAS.Utilities.Math.Functions.smoothMax(x1=crShdArea1,x2=crShdArea2,deltaX=0.01);
   fraSunDir = IDEAS.Utilities.Math.Functions.smoothMin( x1=IDEAS.Utilities.Math.Functions.smoothMax(x1=1-crShdArea/AWin,x2=0,deltaX=0.01),x2=1.0,deltaX=0.01);
 
-  HShaDirTil = HDirTil * fraSunDir;
-  HShaSkyDifTil = fraSunDif * HSkyDifTil;
-  HShaGroDifTil = fraSunDif * HGroDifTil;
+
 
   connect(angInc, iAngInc) annotation (Line(
       points={{-60,-50},{-14,-50},{-14,-50},{40,-50}},
       color={0,0,127},
       smooth=Smooth.None));
+  connect(HShaDirexpr.y, HShaDir.u)
+    annotation (Line(points={{-9,50},{-1.2,50}}, color={0,0,127}));
+  connect(HShaSkyDifexpr.y, HShaSkyDif.u)
+    annotation (Line(points={{-9,30},{-1.2,30}}, color={0,0,127}));
+  connect(HShaGroDifexpr.y, HShaSkyGro.u)
+    annotation (Line(points={{-9,10},{-1.2,10}}, color={0,0,127}));
   annotation (                   Documentation(info="<html>
 <p>
 Shading model of side fins (or similar objects) 
@@ -117,6 +128,10 @@ towards the window.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+July 03, 2026, by Klaas De Jonge:<br/>
+Updates after refactoring of baseclass model to avoid illegal way of connections to avoid warnings.
+</li>
 <li>
 July 18, 2022 by Filip Jorissen:<br/>
 Refactored for <a href=\"https://github.com/open-ideas/IDEAS/issues/1270\">#1270</a> for including thermal effect of screens.


### PR DESCRIPTION
Moved former shading irradiance outputs onto explicit RealExpression and pass-through blocks across the shading components. This keeps the models consistent with the shared interface but simplifies connections. This avoid illegal modelica and avoids warnings.