### PR TITLE
Remove causal prefixes when using buses implemented as expandable connectors.

### DIFF
--- a/IDEAS/BoundaryConditions/SolarIrradiation/RadSolData.mo
+++ b/IDEAS/BoundaryConditions/SolarIrradiation/RadSolData.mo
@@ -8,7 +8,7 @@ model RadSolData "Selects or generates correct solar data for this surface"
     "Simulation information manager for climate data"
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
 protected
-  input IDEAS.Buildings.Components.Interfaces.WeaBus
+  IDEAS.Buildings.Components.Interfaces.WeaBus
     weaBus(numSolBus=sim.numIncAndAziInBus, outputAngles=sim.outputAngles)
     annotation (HideResults=true,Placement(transformation(extent={{90,70},{110,90}})));
 

--- a/IDEAS/LIDEAS/Components/LinearisationInterface.mo
+++ b/IDEAS/LIDEAS/Components/LinearisationInterface.mo
@@ -4,13 +4,13 @@ model LinearisationInterface
 
   inner input IDEAS.Buildings.Components.Interfaces.WindowBus[sim.nWindow]
     winBusIn(each nLay=sim.nLayWin) if sim.linearise;
-  input IDEAS.Buildings.Components.Interfaces.WeaBus weaBus(
+  IDEAS.Buildings.Components.Interfaces.WeaBus weaBus(
     outputAngles=sim.outputAngles,
     final numSolBus=sim.numIncAndAziInBus) if sim.linearise;
   output IDEAS.Buildings.Components.Interfaces.WindowBus[sim.nWindow]
      winBusOut(each nLay=sim.nLayWin) if sim.createOutputs
     "Dummy for getting outputs";
-  output IDEAS.Buildings.Components.Interfaces.WeaBus weaBusOut(
+  IDEAS.Buildings.Components.Interfaces.WeaBus weaBusOut(
     outputAngles=sim.outputAngles,
    final numSolBus=sim.numIncAndAziInBus) if sim.createOutputs;
   inner replaceable


### PR DESCRIPTION
[Section 9.3](https://specification.modelica.org/master/MLS.pdf#section.9.3) of the specs says:
> The matched primitive components of the two connectors must have the same primitive types,
> and flow variables may only connect to other flow variables, stream variables only to other stream
> variables, and causal variables (input/output) only to causal variables (input/output).

`expandable connector`s have an inference mechanism to sort out the causality of signals contained in them. Adding a causal prefix makes it invalid to connect to the bus present in
`IDEAS.BoundaryConditions.SimInfoManager`, for instance, as this one doesn't have such a prefix.
This specific issue was originally discovered in
`IDEAS.BoundaryConditions.SolarIrradiation.RadSolData` at line 176.

This commit removes all prefixes use for instances of `IDEAS.Buildings.Components.Interfaces.WeaBus`, an alternative to this PR would be to carefully study how the class is used and to add the appropriate causal prefixes where they are needed.

I can't find a way for this commit to introduce regressions, but somehow my gut is still worried that it might, I just figured I should disclose it, as I wasn't able to fully test the outcome of the change.